### PR TITLE
Fix 32-bit build

### DIFF
--- a/src/convert_image/avx2.rs
+++ b/src/convert_image/avx2.rs
@@ -111,6 +111,13 @@ macro_rules! fix_to_i16_16x {
     };
 }
 
+#[cfg(target_arch = "x86")]
+unsafe fn _mm256_extract_epi64(a: __m256i, index: i32) -> i64
+{
+    let slice = std::mem::transmute::<__m256i, [i64; 4]>(a);
+    return slice[index as usize];
+}
+
 /// Convert short to 2D short vector (16-wide)
 unsafe fn i16_to_i16x2_16x(x: __m256i) -> (__m256i, __m256i) {
     let y = _mm256_unpacklo_epi16(x, x);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -973,6 +973,7 @@ fn buffers_size() {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 #[test]
 fn over_4gb() {
     bootstrap();


### PR DESCRIPTION
*Description of changes:*

32-bit build was not working:
- avx2 does not have `_mm256_extract_epi64` in 32 bit mode
- test `over_4gb` is designed to run only on 64 bit mode