### PR TITLE
Fix test `yuv_to_rgb_ok`

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -674,6 +674,8 @@ fn rgb_to_yuv_ok() {
 
 #[test]
 fn yuv_to_rgb_ok() {
+    bootstrap();
+
     const MAX_WIDTH: u32 = 34;
     const MAX_HEIGHT: u32 = 4;
 


### PR DESCRIPTION
Test `yuv_to_rgb_ok` was not calling `bootstrap()` at the beginning so when executed alone:

```
cargo test -- yuv_to_rgb_ok

running 1 test
test yuv_to_rgb_ok ... FAILED

failures:

---- yuv_to_rgb_ok stdout ----
thread 'yuv_to_rgb_ok' panicked at 'assertion failed: false', tests\tests.rs:575:19
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.


failures:
    yuv_to_rgb_ok

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 7 filtered out
```

it erroneously return a failure. This is because the library was not initialized while the test assumed that.

The test worked as expected, by luck, when executed together with the other tests. This because some other test initialized the library before `yuv_to_rgb_ok` was started.
