### PR TITLE
Fix crashes to illegal instructions execution

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [build]
-rustflags = ["-C", "target-cpu=native", "-g"]
+rustflags = ["-C", "target-feature=+sse2,+avx,+avx2", "-g"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-C", "target-feature=+sse2,+avx,+avx2", "-g"]

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target
 __pycache__
 /benches/input.*
 /output.*
+/.cargo*

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,18 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 use std::env;
 use std::fs;
 use std::path::Path;
@@ -21,6 +36,9 @@ fn cpuid(functionnumber: u32, output: &mut [u32; 4]) {
 }
 
 fn main() {
+    // This build script generates the cargo build config file (.cargo/config)
+    // The rust flags are set in order to avoid generating illegal instructions
+    // on the machine on which the build is triggered.
     let mut target_features: Vec<&str> = Vec::new();
 
     let features = &mut [0u32; 4];

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,72 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::{__cpuid, _xgetbv};
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::{__cpuid, _xgetbv};
+
+fn cpuid(functionnumber: u32, output: &mut [u32; 4]) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        unsafe {
+            let result = __cpuid(functionnumber);
+            output[0] = result.eax;
+            output[1] = result.ebx;
+            output[2] = result.ecx;
+            output[3] = result.edx;
+        }
+    }
+}
+
+fn main() {
+    let mut target_features: Vec<&str> = Vec::new();
+
+    let features = &mut [0u32; 4];
+    cpuid(0, features);
+
+    if features[0] != 0 {
+        cpuid(1, features);
+        if (features[3] & (1 << 26)) != 0 {
+            target_features.push("+sse2");
+
+            // AVX is supported if all the following conditions hold:
+            // - OS uses XSAVE/XRSTOR
+            // - AVX supported by CPU
+            // - AVX registers are restored at context switch
+            // See https://software.intel.com/en-us/blogs/2011/04/14/is-avx-enabled/
+            let xcr_feature_mask =
+                if (features[2] & (1 << 27)) != 0 && (features[2] & (1 << 28)) != 0 {
+                    unsafe { _xgetbv(0) }
+                } else {
+                    0
+                };
+
+            if (xcr_feature_mask & 0x6) == 0x6 {
+                target_features.push("+avx");
+
+                cpuid(7, features);
+                if (features[1] & (1 << 5)) != 0 {
+                    target_features.push("+avx2");
+                }
+            }
+        }
+    }
+
+    let mut rust_flags = vec!["\"-g\"".to_string()];
+    if !target_features.is_empty() {
+        rust_flags.push("\"-C\"".to_string());
+        rust_flags.push(format!("\"target-feature={}\"", target_features.join(",")));
+    }
+
+    let build_flags = format!("[build]\nrustflags = [{}]\n", rust_flags.join(","));
+
+    let out_dir = env::var_os("CARGO_MANIFEST_DIR").unwrap();
+    let dest_folder = Path::new(&out_dir).join(".cargo");
+    let dest_file = dest_folder.join("config");
+
+    // We want to abort build if configuration file is not generated properly, so the unwrap()
+    fs::create_dir_all(dest_folder).unwrap();
+    fs::write(&dest_file, build_flags).unwrap()
+}

--- a/src/convert_image/avx2.rs
+++ b/src/convert_image/avx2.rs
@@ -19,9 +19,29 @@ use crate::convert_image::sse2;
 use crate::convert_image::x86;
 
 #[cfg(target_arch = "x86")]
-use core::arch::x86::*;
+use core::arch::x86::{
+    __m128i, __m256i, _mm256_add_epi16, _mm256_add_epi32, _mm256_cmpeq_epi32, _mm256_loadu2_m128i,
+    _mm256_loadu_si256, _mm256_madd_epi16, _mm256_mulhi_epu16, _mm256_or_si256, _mm256_packs_epi32,
+    _mm256_packus_epi16, _mm256_permute2x128_si256, _mm256_permutevar8x32_epi32, _mm256_set1_epi16,
+    _mm256_set1_epi32, _mm256_set_epi32, _mm256_set_epi64x, _mm256_set_m128i, _mm256_setzero_si256,
+    _mm256_slli_epi16, _mm256_slli_epi32, _mm256_srai_epi16, _mm256_srai_epi32, _mm256_srli_epi16,
+    _mm256_srli_epi32, _mm256_srli_si256, _mm256_storeu_si256, _mm256_sub_epi16,
+    _mm256_unpackhi_epi16, _mm256_unpackhi_epi8, _mm256_unpacklo_epi16, _mm256_unpacklo_epi32,
+    _mm256_unpacklo_epi64, _mm256_unpacklo_epi8, _mm_loadu_si128, _mm_setzero_si128,
+};
+
 #[cfg(target_arch = "x86_64")]
-use core::arch::x86_64::*;
+use core::arch::x86_64::{
+    __m128i, __m256i, _mm256_add_epi16, _mm256_add_epi32, _mm256_cmpeq_epi32, _mm256_extract_epi64,
+    _mm256_loadu2_m128i, _mm256_loadu_si256, _mm256_madd_epi16, _mm256_mulhi_epu16,
+    _mm256_or_si256, _mm256_packs_epi32, _mm256_packus_epi16, _mm256_permute2x128_si256,
+    _mm256_permutevar8x32_epi32, _mm256_set1_epi16, _mm256_set1_epi32, _mm256_set_epi32,
+    _mm256_set_epi64x, _mm256_set_m128i, _mm256_setzero_si256, _mm256_slli_epi16,
+    _mm256_slli_epi32, _mm256_srai_epi16, _mm256_srai_epi32, _mm256_srli_epi16, _mm256_srli_epi32,
+    _mm256_srli_si256, _mm256_storeu_si256, _mm256_sub_epi16, _mm256_unpackhi_epi16,
+    _mm256_unpackhi_epi8, _mm256_unpacklo_epi16, _mm256_unpacklo_epi32, _mm256_unpacklo_epi64,
+    _mm256_unpacklo_epi8, _mm_loadu_si128, _mm_setzero_si128,
+};
 
 const LANE_COUNT: usize = 32;
 const LRGB_TO_YUV_WG_SIZE: usize = 4;

--- a/src/convert_image/sse2.rs
+++ b/src/convert_image/sse2.rs
@@ -18,9 +18,26 @@ use crate::convert_image::common::*;
 use crate::convert_image::x86;
 
 #[cfg(target_arch = "x86")]
-use core::arch::x86::*;
+use core::arch::x86::{
+    __m128i, _mm_add_epi16, _mm_add_epi32, _mm_cmpeq_epi32, _mm_cvtsi128_si32, _mm_loadl_epi64,
+    _mm_loadu_si128, _mm_madd_epi16, _mm_mulhi_epu16, _mm_or_si128, _mm_packs_epi32,
+    _mm_packus_epi16, _mm_set1_epi16, _mm_set1_epi32, _mm_set1_epi64x, _mm_set_epi32,
+    _mm_setzero_si128, _mm_shuffle_epi32, _mm_slli_epi16, _mm_slli_epi32, _mm_srai_epi16,
+    _mm_srai_epi32, _mm_srli_epi16, _mm_srli_epi32, _mm_srli_si128, _mm_storeu_si128,
+    _mm_sub_epi16, _mm_unpackhi_epi16, _mm_unpackhi_epi8, _mm_unpacklo_epi16, _mm_unpacklo_epi32,
+    _mm_unpacklo_epi64, _mm_unpacklo_epi8,
+};
+
 #[cfg(target_arch = "x86_64")]
-use core::arch::x86_64::*;
+use core::arch::x86_64::{
+    __m128i, _mm_add_epi16, _mm_add_epi32, _mm_cmpeq_epi32, _mm_cvtsi128_si32, _mm_loadl_epi64,
+    _mm_loadu_si128, _mm_madd_epi16, _mm_mulhi_epu16, _mm_or_si128, _mm_packs_epi32,
+    _mm_packus_epi16, _mm_set1_epi16, _mm_set1_epi32, _mm_set1_epi64x, _mm_set_epi32,
+    _mm_setzero_si128, _mm_shuffle_epi32, _mm_slli_epi16, _mm_slli_epi32, _mm_srai_epi16,
+    _mm_srai_epi32, _mm_srli_epi16, _mm_srli_epi32, _mm_srli_si128, _mm_storeu_si128,
+    _mm_sub_epi16, _mm_unpackhi_epi16, _mm_unpackhi_epi8, _mm_unpacklo_epi16, _mm_unpacklo_epi32,
+    _mm_unpacklo_epi64, _mm_unpacklo_epi8,
+};
 
 const LANE_COUNT: usize = 16;
 const LRGB_TO_YUV_WG_SIZE: usize = 4;


### PR DESCRIPTION
*Description of changes:*
Have the rust global build script `build.rs` generate the cargo config file.

The cargo config file will contain the intersection of:
- The instruction sets required by dcv-color-primitives (after a research it can be found it uses sse2, avx, avx2 and no more)
- The instruction sets really supported on the machine where the build happens

In this way, we prevent invalid instructions being executed on machines that do not support them.

I tested this on a RHEL6 machine (without avx support) and the generated cargo file looks the following:
```text
[build]
rustflags = ["-g","-C","target-feature=+sse2"]
```

`cargo test` works fine.

Instead, on another machine with avx2 support the following config file is generated:
```txt
[build]
rustflags = ["-g","-C","target-feature=+sse2,+avx,+avx2"]
```
