### PR TITLE
build.rs: pass target-feature values directly to the compiler

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-g"]


### PR DESCRIPTION
The target-feature in the .cargo/config file generated by
the build.rs script are ignored on the first build.rs since
cargo does not reload the config file. They are applied
from the second build.
Passing those values directly to the compiler is better
since they are immediately used, also in the first build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
