### PR TITLE
Changed meson to print output from cargo and fail on failed cargo build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -91,7 +91,14 @@ else
   cargo_target = ['build', ]
 endif
 
-run_command('cargo', cargo_target)
+cargo_result = run_command('cargo', cargo_target)
+
+message(cargo_result.stdout())
+message(cargo_result.stderr())
+
+if cargo_result.returncode() != 0
+    error('-- cargo build failed')
+endif
 
 dcp_lib_path = meson.source_root() / 'target' / dcp_build_dir
 


### PR DESCRIPTION
*Description of changes:*
- meson will now fail if cargo fails to build the artifacts
- output from cargo (stdout/stderr) will now be printed along meson output for easier diagnosis of failing builds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
