### PR TITLE
Fix C unit tests warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,6 @@ elif cc.get_id() == 'gcc' or cc.get_id() == 'clang'
     '-Werror=nonnull',
     '-Werror=init-self',
     '-Werror=main',
-    '-Werror=missing-braces',
     '-Werror=sequence-point',
     '-Werror=return-type',
     '-Werror=trigraphs',
@@ -69,8 +68,10 @@ elif cc.get_id() == 'gcc' or cc.get_id() == 'clang'
     '-Werror=int-to-pointer-cast',
     '-Werror=pointer-to-int-cast',
     '-Werror=empty-body',
+    '-Wsign-compare',
     '-fno-strict-aliasing',
     '-Wno-int-conversion',
+    '-Wno-missing-braces',
   ]
 else
   test_cflags = []

--- a/src/convert_image/avx2.rs
+++ b/src/convert_image/avx2.rs
@@ -148,13 +148,8 @@ fn split_planes<'a>(
     src_buffers
         .split_first()
         .and_then(|(y, uv)| match last_src_plane {
-            0 => {
-                if interplane_split <= y.len() {
-                    Some(y.split_at(interplane_split))
-                } else {
-                    None
-                }
-            }
+            0 if interplane_split <= y.len() => Some(y.split_at(interplane_split)),
+            0 => None,
             _ => uv.split_first().map(|(uv, _)| (&y[..], &uv[..])),
         })
 }
@@ -168,13 +163,8 @@ fn split_planes_mut<'a>(
     src_buffers
         .split_first_mut()
         .and_then(|(y, uv)| match last_src_plane {
-            0 => {
-                if interplane_split <= y.len() {
-                    Some(y.split_at_mut(interplane_split))
-                } else {
-                    None
-                }
-            }
+            0 if interplane_split <= y.len() => Some(y.split_at_mut(interplane_split)),
+            0 => None,
             _ => uv
                 .split_first_mut()
                 .map(move |(uv, _)| (&mut y[..], &mut uv[..])),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Fix C unit tests warnings
* Shorten split_planes function

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
