### PR TITLE
Wip/fabiosky/asm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 /.cargo*
 /.vscode*
 Cargo.lock
+benches/output*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ paste = "1.0"
 
 [dev-dependencies]
 criterion = "0.3"
+affinity = "0.1.2"
+thread-priority = "0.8.0"
 itertools = "0.10"
 rand = "0.8"
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ Both standard range (0-235) and full range (0-255) are supported.
 
 ## Requirements
 
-* Rust 1.55 and newer (until DCP 0.2: At least Rust 1.39)
-* Python3 and Fractions module (needed only if you want to execute the benchmark)
+* Rust 1.59 and newer (until DCP 0.2: At least Rust 1.39)
+* Criterion module (needed only if you want to execute the benchmark)
 
 ### Windows
 
 * Install rustup: https://www.rust-lang.org/tools/install
 * If you want to execute the benchmark:
+    * Install criterion: cargo install cargo-criterion
     * Install Python 3: https://www.python.org/downloads/
-    * Install fraction module: `pip install Fraction`
 
 ### Linux
 
@@ -61,8 +61,8 @@ Both standard range (0-235) and full range (0-255) are supported.
     curl https://sh.rustup.rs -sSf | sh
     ```
 * If you want to execute the benchmark:
+    * Install criterion: cargo install cargo-criterion
     * Install Python 3 (example for Ubuntu): `apt install python3`
-    * Install fraction module: `pip install Fraction`
 
 You may require administrative privileges.
 
@@ -88,7 +88,7 @@ cargo test
 Run benchmark:
 ```
 python benches/geninput.py
-cargo bench
+cargo criterion
 ```
 
 ## WebAssembly

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The library is currenty able to convert the following pixel formats:
 
 | Source pixel format  | Destination pixel formats  |
 | -------------------- | -------------------------- |
-| ARGB                 | I420, I444, NV12           |
+| ARGB                 | I420, I444, NV12, RGB      |
 | BGR                  | I420, I444, NV12           |
 | BGRA                 | I420, I444, NV12, RGB      |
 | I420                 | BGRA                       |

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -181,7 +181,7 @@ fn bgra_i420_input(width: usize, height: usize, output_buffer: &mut [u8]) -> Ben
     let input_buffer = alloc_buffer(src_size, false);
     load_buffer(input_buffer, BGRA_INPUT, true)?;
 
-    let input_data: &[&[u8]] = &[&input_buffer];
+    let input_data: &[&[u8]] = &[input_buffer];
     let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
     let (u_data, v_data) = uv_data.split_at_mut(width * height / 4);
     let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
@@ -219,7 +219,7 @@ fn bgra_i444_input(width: usize, height: usize, output_buffer: &mut [u8]) -> Ben
     let input_buffer = alloc_buffer(src_size, false);
     load_buffer(input_buffer, BGRA_INPUT, true)?;
 
-    let input_data: &[&[u8]] = &[&input_buffer];
+    let input_data: &[&[u8]] = &[input_buffer];
     let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
     let (u_data, v_data) = uv_data.split_at_mut(width * height);
     let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
@@ -260,7 +260,7 @@ fn bgra_i420(output_path: &str, width: usize, height: usize) -> BenchmarkResult<
 
     let output_buffer = alloc_buffer(dst_size, true);
 
-    let input_data: &[&[u8]] = &[&input_buffer];
+    let input_data: &[&[u8]] = &[input_buffer];
     let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
     let (u_data, v_data) = uv_data.split_at_mut(width * height / 4);
     let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
@@ -301,7 +301,7 @@ fn bgra_i444(output_path: &str, width: usize, height: usize) -> BenchmarkResult<
 
     let output_buffer = alloc_buffer(dst_size, true);
 
-    let input_data: &[&[u8]] = &[&input_buffer];
+    let input_data: &[&[u8]] = &[input_buffer];
     let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
     let (u_data, v_data) = uv_data.split_at_mut(width * height);
     let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
@@ -342,7 +342,7 @@ fn bgr_i420(output_path: &str, width: usize, height: usize) -> BenchmarkResult<D
 
     let output_buffer = alloc_buffer(dst_size, true);
 
-    let input_data: &[&[u8]] = &[&input_buffer];
+    let input_data: &[&[u8]] = &[input_buffer];
     let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
     let (u_data, v_data) = uv_data.split_at_mut(width * height / 4);
     let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
@@ -383,7 +383,7 @@ fn bgr_i444(output_path: &str, width: usize, height: usize) -> BenchmarkResult<D
 
     let output_buffer = alloc_buffer(dst_size, true);
 
-    let input_data: &[&[u8]] = &[&input_buffer];
+    let input_data: &[&[u8]] = &[input_buffer];
     let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
     let (u_data, v_data) = uv_data.split_at_mut(width * height);
     let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
@@ -436,7 +436,7 @@ fn i420_bgra(
         &input_buffer[y_plane_size..(y_plane_size + u_plane_size)],
         &input_buffer[(y_plane_size + u_plane_size)..],
     ];
-    let output_data: &mut [&mut [u8]] = &mut [&mut output_buffer[..]];
+    let output_data: &mut [&mut [u8]] = &mut [&mut *output_buffer];
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::I420,
@@ -486,7 +486,7 @@ fn i444_bgra(
         &input_buffer[y_plane_size..(y_plane_size + u_plane_size)],
         &input_buffer[(y_plane_size + u_plane_size)..],
     ];
-    let output_data: &mut [&mut [u8]] = &mut [&mut output_buffer[..]];
+    let output_data: &mut [&mut [u8]] = &mut [&mut *output_buffer];
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::I444,
@@ -524,8 +524,8 @@ fn bgra_rgb(output_path: &str, width: usize, height: usize) -> BenchmarkResult<D
 
     let output_buffer = alloc_buffer(dst_size, true);
 
-    let input_data: &[&[u8]] = &[&input_buffer];
-    let output_data: &mut [&mut [u8]] = &mut [&mut output_buffer[..]];
+    let input_data: &[&[u8]] = &[input_buffer];
+    let output_data: &mut [&mut [u8]] = &mut [&mut *output_buffer];
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
@@ -563,8 +563,8 @@ fn rgb_bgra(output_path: &str, width: usize, height: usize) -> BenchmarkResult<D
 
     let output_buffer = alloc_buffer(dst_size, true);
 
-    let input_data: &[&[u8]] = &[&input_buffer];
-    let output_data: &mut [&mut [u8]] = &mut [&mut output_buffer[..]];
+    let input_data: &[&[u8]] = &[input_buffer];
+    let output_data: &mut [&mut [u8]] = &mut [&mut *output_buffer];
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Rgb,
@@ -623,6 +623,7 @@ fn convert_to(
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 fn convert_from_to(
     group: &mut BenchmarkGroup<measurement::WallTime>,
     name: &str,

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,4 +1,4 @@
-use affinity::set_process_affinity;
+use affinity::set_thread_affinity;
 use criterion::*;
 use std::alloc::{alloc, dealloc, Layout};
 use std::error;
@@ -596,7 +596,7 @@ fn rgb_bgra(output_path: &str, width: usize, height: usize) -> BenchmarkResult<D
 fn configure_process() {
     let cores: Vec<usize> = (0..1).collect();
 
-    set_process_affinity(&cores).unwrap();
+    set_thread_affinity(&cores).unwrap();
     set_current_thread_priority(ThreadPriority::Max).unwrap();
 }
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,27 +1,72 @@
+use affinity::set_process_affinity;
 use criterion::*;
+use std::alloc::{alloc, dealloc, Layout};
 use std::error;
 use std::fmt;
 use std::fs::{remove_file, OpenOptions};
-use std::io::BufRead;
-use std::io::{Cursor, Read, Seek, SeekFrom, Write};
+use std::io::{Cursor, Read, Write};
 use std::path::Path;
+use std::slice::from_raw_parts_mut;
 use std::time::Duration;
 use std::time::Instant;
+use thread_priority::{set_current_thread_priority, ThreadPriority};
 
 use dcp::*;
 use dcv_color_primitives as dcp;
 
-const NV12_OUTPUT: &str = "./output.nv12";
-const BGRA_OUTPUT: &str = "./output.bgra";
-const RGB_BGRA_OUTPUT: &str = "./rgb_output.bgra";
-const BGRA_RGB_OUTPUT: &str = "./bgra_rgb_output.rgb";
-const I420_OUTPUT: &str = "./i420_output.bgra";
-const I444_OUTPUT: &str = "./i444_output.bgra";
-const BGRA_I420_OUTPUT: &str = "./bgra_i420_output.i420";
-const BGRA_I444_OUTPUT: &str = "./bgra_i444_output.i444";
+const BGRA_INPUT: &[u8] = include_bytes!("input.bgra");
+const RGB_INPUT: &[u8] = include_bytes!("input.rgb");
+
+const BGRA_I420_OUTPUT: &str = "./benches/output_bgra.i420";
+const BGRA_I444_OUTPUT: &str = "./benches/output_bgra.i444";
+const BGR_I420_OUTPUT: &str = "./benches/output_bgr.i420";
+const BGR_I444_OUTPUT: &str = "./benches/output_bgr.i444";
+const I420_BGRA_OUTPUT: &str = "./benches/output_i420.bgra";
+const I444_BGRA_OUTPUT: &str = "./benches/output_i444.bgra";
+const BGRA_RGB_OUTPUT: &str = "./benches/output_bgra.rgb";
+const RGB_BGRA_OUTPUT: &str = "./benches/output_rgb.bgra";
 
 const SAMPLE_SIZE: usize = 22;
 const PAGE_SIZE: usize = 4096;
+
+struct BenchmarkInput<'a> {
+    width: usize,
+    height: usize,
+    name: &'a str,
+}
+
+const INPUTS: &[BenchmarkInput] = &[
+    BenchmarkInput {
+        width: 640,
+        height: 480,
+        name: "480",
+    },
+    BenchmarkInput {
+        width: 1280,
+        height: 720,
+        name: "720",
+    },
+    BenchmarkInput {
+        width: 1920,
+        height: 1080,
+        name: "1080",
+    },
+    BenchmarkInput {
+        width: 2560,
+        height: 1440,
+        name: "2k",
+    },
+    BenchmarkInput {
+        width: 3840,
+        height: 2160,
+        name: "4k",
+    },
+    BenchmarkInput {
+        width: 4096,
+        height: 4096,
+        name: "max",
+    },
+];
 
 #[derive(Debug, Clone)]
 struct BenchmarkError;
@@ -39,6 +84,11 @@ impl error::Error for BenchmarkError {
 }
 
 type BenchmarkResult<T> = std::result::Result<T, Box<dyn error::Error>>;
+type Converter = fn(output_path: &str, width: usize, height: usize) -> BenchmarkResult<Duration>;
+type InputConverter =
+    fn(width: usize, height: usize, output_buffer: &mut [u8]) -> BenchmarkResult<()>;
+type OutputConverter =
+    fn(output_path: &str, width: usize, height: usize, source: &[u8]) -> BenchmarkResult<Duration>;
 
 fn skip_line(file: &mut Cursor<&[u8]>) -> BenchmarkResult<()> {
     let mut byte = [0; 1];
@@ -49,112 +99,91 @@ fn skip_line(file: &mut Cursor<&[u8]>) -> BenchmarkResult<()> {
     Ok(())
 }
 
-fn read_line(file: &mut Cursor<&[u8]>) -> BenchmarkResult<String> {
-    let mut string = String::new();
-    let written_chars = file.read_line(&mut string)?;
+fn alloc_buffer<'a>(len: usize, commit: bool) -> &'a mut [u8] {
+    #[allow(unsafe_code)]
+    unsafe {
+        let layout = Layout::from_size_align_unchecked(len, 64);
+        let ptr = alloc(layout);
 
-    let result = match written_chars {
-        0 => Err(BenchmarkError),
-        _ => Ok(string),
-    };
+        if commit {
+            for i in (0..len).step_by(PAGE_SIZE) {
+                *ptr.add(i) = 0;
+            }
 
-    result.map_err(|e| e.into())
+            *ptr.add(len - 1) = 0;
+        }
+
+        from_raw_parts_mut(ptr, len)
+    }
 }
 
-fn pnm_size(file: &mut Cursor<&[u8]>) -> BenchmarkResult<(u32, u32)> {
-    file.seek(SeekFrom::Start(0))?;
-    skip_line(file)?;
+fn dealloc_buffer(buf: &mut [u8], len: usize) {
+    #[allow(unsafe_code)]
+    unsafe {
+        let layout = Layout::from_size_align_unchecked(len, 64);
+        let ptr = buf.as_mut_ptr();
 
-    let dimensions: Vec<_> = read_line(file)?
-        .split_whitespace()
-        .map(|s| s.parse::<u32>().unwrap())
-        .collect();
-
-    let width = dimensions.get(0).ok_or(BenchmarkError)?;
-    let height = dimensions.get(1).ok_or(BenchmarkError)?;
-    Ok((*width, *height))
+        dealloc(ptr, layout)
+    }
 }
 
-fn pnm_data(file: &mut Cursor<&[u8]>) -> BenchmarkResult<(u32, u32, Vec<u8>)> {
-    file.seek(SeekFrom::Start(0))?;
-    let (width, height) = pnm_size(file)?;
+fn load_buffer(buf: &mut [u8], from: &[u8], skip_header: bool) -> BenchmarkResult<()> {
+    let mut input_file = Cursor::new(from);
 
-    let size: usize = (width as usize) * (height as usize);
-    let mut x: Vec<u8> = Vec::with_capacity(size);
-    skip_line(file)?;
-    file.read_to_end(&mut x)?;
-
-    Ok((width, height, x))
-}
-
-fn bgra_nv12(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResult<Duration> {
-    let (mut width, height, input_buffer) = { pnm_data(input_file)? };
-    width /= 4;
-
-    // Allocate output
-    let dst_size: usize = 3 * (width as usize) * (height as usize) / 2;
-    let mut output_buffer: Vec<u8> = vec![0; dst_size];
-    for i in (0..dst_size).step_by(PAGE_SIZE) {
-        output_buffer[i] = 0;
+    if skip_header {
+        skip_line(&mut input_file)?;
+        skip_line(&mut input_file)?;
     }
 
-    let input_data: &[&[u8]] = &[&input_buffer];
-    let output_data: &mut [&mut [u8]] = &mut [&mut output_buffer[..]];
+    input_file.read_exact(buf)?;
 
-    let src_format = ImageFormat {
-        pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
-        num_planes: 1,
-    };
+    Ok(())
+}
 
-    let dst_format = ImageFormat {
-        pixel_format: PixelFormat::Nv12,
-        color_space: ColorSpace::Bt601,
-        num_planes: 1,
-    };
+fn save_buffer(buf: &[u8], to: &str, width: usize, height: usize) -> BenchmarkResult<()> {
+    if !Path::new(to).exists() {
+        let mut file = OpenOptions::new().write(true).create(true).open(to)?;
 
+        write!(file, "P5\n{} {}\n255\n", width, height)?;
+        file.write_all(buf)?;
+    }
+
+    Ok(())
+}
+
+fn convert_buffer(
+    width: usize,
+    height: usize,
+    src_format: &ImageFormat,
+    input_data: &[&[u8]],
+    dst_format: &ImageFormat,
+    output_data: &mut [&mut [u8]],
+) -> BenchmarkResult<Duration> {
     let start = Instant::now();
+
     convert_image(
-        width,
-        height,
-        &src_format,
+        width as u32,
+        height as u32,
+        src_format,
         None,
         input_data,
-        &dst_format,
+        dst_format,
         None,
         output_data,
     )?;
 
-    let elapsed = start.elapsed();
-
-    if !Path::new(output_path).exists() {
-        let mut buffer = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(output_path)?;
-        write!(buffer, "P5\n{} {}\n255\n", width, height + height / 2)?;
-        buffer.write_all(&output_buffer)?;
-    }
-
-    Ok(elapsed)
+    Ok(start.elapsed())
 }
 
-fn bgra_i420(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResult<Duration> {
-    let (mut width, height, input_buffer) = { pnm_data(input_file)? };
-    width /= 4;
-    let w: usize = width as usize;
-    let h: usize = height as usize;
+fn bgra_i420_input(width: usize, height: usize, output_buffer: &mut [u8]) -> BenchmarkResult<()> {
+    let src_size = 4 * width * height;
 
-    // Allocate output
-    let dst_size: usize = 3 * (width as usize) * (height as usize) / 2;
-    let mut output_buffer: Vec<u8> = vec![0; dst_size];
-    for i in (0..dst_size).step_by(PAGE_SIZE) {
-        output_buffer[i] = 0;
-    }
+    let input_buffer = alloc_buffer(src_size, false);
+    load_buffer(input_buffer, BGRA_INPUT, true)?;
 
     let input_data: &[&[u8]] = &[&input_buffer];
-    let (y_data, uv_data) = output_buffer.split_at_mut(w * h);
-    let (u_data, v_data) = uv_data.split_at_mut(w * h / 4);
+    let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
+    let (u_data, v_data) = uv_data.split_at_mut(width * height / 4);
     let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
 
     let src_format = ImageFormat {
@@ -162,17 +191,15 @@ fn bgra_i420(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
         color_space: ColorSpace::Lrgb,
         num_planes: 1,
     };
-
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::I420,
         color_space: ColorSpace::Bt601,
         num_planes: 3,
     };
 
-    let start = Instant::now();
     convert_image(
-        width,
-        height,
+        width as u32,
+        height as u32,
         &src_format,
         None,
         input_data,
@@ -181,36 +208,20 @@ fn bgra_i420(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
         output_data,
     )?;
 
-    let elapsed = start.elapsed();
+    dealloc_buffer(input_buffer, src_size);
 
-    if !Path::new(output_path).exists() {
-        let mut buffer = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(output_path)?;
-        write!(buffer, "P5\n{} {}\n255\n", width, height + height / 2)?;
-        buffer.write_all(&output_buffer)?;
-    }
-
-    Ok(elapsed)
+    Ok(())
 }
 
-fn bgra_i444(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResult<Duration> {
-    let (mut width, height, input_buffer) = { pnm_data(input_file)? };
-    width /= 4;
-    let w: usize = width as usize;
-    let h: usize = height as usize;
+fn bgra_i444_input(width: usize, height: usize, output_buffer: &mut [u8]) -> BenchmarkResult<()> {
+    let src_size = 4 * width * height;
 
-    // Allocate output
-    let dst_size: usize = 3 * (width as usize) * (height as usize);
-    let mut output_buffer: Vec<u8> = vec![0; dst_size];
-    for i in (0..dst_size).step_by(PAGE_SIZE) {
-        output_buffer[i] = 0;
-    }
+    let input_buffer = alloc_buffer(src_size, false);
+    load_buffer(input_buffer, BGRA_INPUT, true)?;
 
     let input_data: &[&[u8]] = &[&input_buffer];
-    let (y_data, uv_data) = output_buffer.split_at_mut(w * h);
-    let (u_data, v_data) = uv_data.split_at_mut(w * h);
+    let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
+    let (u_data, v_data) = uv_data.split_at_mut(width * height);
     let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
 
     let src_format = ImageFormat {
@@ -218,17 +229,15 @@ fn bgra_i444(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
         color_space: ColorSpace::Lrgb,
         num_planes: 1,
     };
-
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::I444,
         color_space: ColorSpace::Bt601,
         num_planes: 3,
     };
 
-    let start = Instant::now();
     convert_image(
-        width,
-        height,
+        width as u32,
+        height as u32,
         &src_format,
         None,
         input_data,
@@ -237,192 +246,191 @@ fn bgra_i444(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
         output_data,
     )?;
 
-    let elapsed = start.elapsed();
+    dealloc_buffer(input_buffer, src_size);
 
-    if !Path::new(output_path).exists() {
-        let mut buffer = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(output_path)?;
-        write!(buffer, "P5\n{} {}\n255\n", width, height + height + height)?;
-        buffer.write_all(&output_buffer)?;
-    }
-
-    Ok(elapsed)
+    Ok(())
 }
 
-fn nv12_bgra(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResult<Duration> {
-    let (width, mut height, input_buffer) = { pnm_data(input_file)? };
-    height = 2 * height / 3;
+fn bgra_i420(output_path: &str, width: usize, height: usize) -> BenchmarkResult<Duration> {
+    let src_size = 4 * width * height;
+    let dst_size = 3 * width * height / 2;
 
-    // Allocate output
-    let dst_size: usize = 4 * (width as usize) * (height as usize);
-    let mut output_buffer: Vec<u8> = vec![0; dst_size];
-    for i in (0..dst_size).step_by(PAGE_SIZE) {
-        output_buffer[i] = 0;
-    }
+    let input_buffer = alloc_buffer(src_size, false);
+    load_buffer(input_buffer, BGRA_INPUT, true)?;
+
+    let output_buffer = alloc_buffer(dst_size, true);
 
     let input_data: &[&[u8]] = &[&input_buffer];
-    let output_data: &mut [&mut [u8]] = &mut [&mut output_buffer[..]];
+    let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
+    let (u_data, v_data) = uv_data.split_at_mut(width * height / 4);
+    let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
 
     let src_format = ImageFormat {
-        pixel_format: PixelFormat::Nv12,
+        pixel_format: PixelFormat::Bgra,
+        color_space: ColorSpace::Lrgb,
+        num_planes: 1,
+    };
+    let dst_format = ImageFormat {
+        pixel_format: PixelFormat::I420,
         color_space: ColorSpace::Bt601,
-        num_planes: 1,
+        num_planes: 3,
     };
 
-    let dst_format = ImageFormat {
-        pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
-        num_planes: 1,
-    };
-
-    let start = Instant::now();
-    convert_image(
+    let elapsed = convert_buffer(
         width,
         height,
         &src_format,
-        None,
         input_data,
         &dst_format,
-        None,
         output_data,
     )?;
 
-    let elapsed = start.elapsed();
-
-    // Write to file
-    if !Path::new(output_path).exists() {
-        let mut buffer = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(output_path)?;
-        write!(buffer, "P5\n{} {}\n255\n", 4 * width, height)?;
-        buffer.write_all(&output_buffer)?;
-    }
+    save_buffer(output_buffer, output_path, width, height + height / 2)?;
+    dealloc_buffer(input_buffer, src_size);
+    dealloc_buffer(output_buffer, dst_size);
 
     Ok(elapsed)
 }
 
-fn rgb_bgra(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResult<Duration> {
-    let (mut width, height, input_buffer) = { pnm_data(input_file)? };
-    width /= 3;
+fn bgra_i444(output_path: &str, width: usize, height: usize) -> BenchmarkResult<Duration> {
+    let src_size = 4 * width * height;
+    let dst_size = 3 * width * height;
 
-    // Allocate output
-    let dst_size: usize = 4 * (width as usize) * (height as usize);
-    let mut output_buffer: Vec<u8> = vec![0; dst_size];
-    for i in (0..dst_size).step_by(PAGE_SIZE) {
-        output_buffer[i] = 0;
-    }
+    let input_buffer = alloc_buffer(src_size, false);
+    load_buffer(input_buffer, BGRA_INPUT, true)?;
+
+    let output_buffer = alloc_buffer(dst_size, true);
 
     let input_data: &[&[u8]] = &[&input_buffer];
-    let output_data: &mut [&mut [u8]] = &mut [&mut output_buffer[..]];
-
-    let src_format = ImageFormat {
-        pixel_format: PixelFormat::Rgb,
-        color_space: ColorSpace::Lrgb,
-        num_planes: 1,
-    };
-
-    let dst_format = ImageFormat {
-        pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
-        num_planes: 1,
-    };
-
-    let start = Instant::now();
-    convert_image(
-        width,
-        height,
-        &src_format,
-        None,
-        input_data,
-        &dst_format,
-        None,
-        output_data,
-    )?;
-
-    let elapsed = start.elapsed();
-
-    // Write to file
-    if !Path::new(output_path).exists() {
-        let mut buffer = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(output_path)?;
-        write!(buffer, "P5\n{} {}\n255\n", 4 * width, height)?;
-        buffer.write_all(&output_buffer)?;
-    }
-
-    Ok(elapsed)
-}
-
-fn bgra_rgb(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResult<Duration> {
-    let (mut width, height, input_buffer) = { pnm_data(input_file)? };
-    width /= 4;
-
-    // Allocate output
-    let dst_size: usize = 3 * (width as usize) * (height as usize);
-    let mut output_buffer: Vec<u8> = vec![0; dst_size];
-    for i in (0..dst_size).step_by(PAGE_SIZE) {
-        output_buffer[i] = 0;
-    }
-
-    let input_data: &[&[u8]] = &[&input_buffer];
-    let output_data: &mut [&mut [u8]] = &mut [&mut output_buffer[..]];
+    let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
+    let (u_data, v_data) = uv_data.split_at_mut(width * height);
+    let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
         color_space: ColorSpace::Lrgb,
         num_planes: 1,
     };
-
     let dst_format = ImageFormat {
-        pixel_format: PixelFormat::Rgb,
-        color_space: ColorSpace::Lrgb,
-        num_planes: 1,
+        pixel_format: PixelFormat::I444,
+        color_space: ColorSpace::Bt601,
+        num_planes: 3,
     };
 
-    let start = Instant::now();
-    convert_image(
+    let elapsed = convert_buffer(
         width,
         height,
         &src_format,
-        None,
         input_data,
         &dst_format,
-        None,
         output_data,
     )?;
 
-    let elapsed = start.elapsed();
-
-    // Write to file
-    if !Path::new(output_path).exists() {
-        let mut buffer = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(output_path)?;
-        write!(buffer, "P5\n{} {}\n255\n", 3 * width, height)?;
-        buffer.write_all(&output_buffer)?;
-    }
+    save_buffer(output_buffer, output_path, width, 3 * height)?;
+    dealloc_buffer(input_buffer, src_size);
+    dealloc_buffer(output_buffer, dst_size);
 
     Ok(elapsed)
 }
 
-fn i420_bgra(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResult<Duration> {
-    let (width, mut height, input_buffer) = { pnm_data(input_file)? };
-    height = 2 * height / 3;
+fn bgr_i420(output_path: &str, width: usize, height: usize) -> BenchmarkResult<Duration> {
+    let src_size = 3 * width * height;
+    let dst_size = 3 * width * height / 2;
 
-    // Allocate output
-    let dst_size: usize = 4 * (width as usize) * (height as usize);
-    let y_plane_size: usize = (width as usize) * (height as usize);
-    let u_plane_size: usize = y_plane_size / 4;
-    let mut output_buffer: Vec<u8> = vec![0; dst_size];
-    for i in (0..dst_size).step_by(PAGE_SIZE) {
-        output_buffer[i] = 0;
-    }
+    let input_buffer = alloc_buffer(src_size, false);
+    load_buffer(input_buffer, RGB_INPUT, true)?;
 
+    let output_buffer = alloc_buffer(dst_size, true);
+
+    let input_data: &[&[u8]] = &[&input_buffer];
+    let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
+    let (u_data, v_data) = uv_data.split_at_mut(width * height / 4);
+    let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
+
+    let src_format = ImageFormat {
+        pixel_format: PixelFormat::Bgr,
+        color_space: ColorSpace::Lrgb,
+        num_planes: 1,
+    };
+    let dst_format = ImageFormat {
+        pixel_format: PixelFormat::I420,
+        color_space: ColorSpace::Bt601,
+        num_planes: 3,
+    };
+
+    let elapsed = convert_buffer(
+        width,
+        height,
+        &src_format,
+        input_data,
+        &dst_format,
+        output_data,
+    )?;
+
+    save_buffer(output_buffer, output_path, width, height + height / 2)?;
+    dealloc_buffer(input_buffer, src_size);
+    dealloc_buffer(output_buffer, dst_size);
+
+    Ok(elapsed)
+}
+
+fn bgr_i444(output_path: &str, width: usize, height: usize) -> BenchmarkResult<Duration> {
+    let src_size = 3 * width * height;
+    let dst_size = 3 * width * height;
+
+    let input_buffer = alloc_buffer(src_size, false);
+    load_buffer(input_buffer, RGB_INPUT, true)?;
+
+    let output_buffer = alloc_buffer(dst_size, true);
+
+    let input_data: &[&[u8]] = &[&input_buffer];
+    let (y_data, uv_data) = output_buffer.split_at_mut(width * height);
+    let (u_data, v_data) = uv_data.split_at_mut(width * height);
+    let output_data: &mut [&mut [u8]] = &mut [&mut *y_data, &mut *u_data, &mut *v_data];
+
+    let src_format = ImageFormat {
+        pixel_format: PixelFormat::Bgr,
+        color_space: ColorSpace::Lrgb,
+        num_planes: 1,
+    };
+    let dst_format = ImageFormat {
+        pixel_format: PixelFormat::I444,
+        color_space: ColorSpace::Bt601,
+        num_planes: 3,
+    };
+
+    let elapsed = convert_buffer(
+        width,
+        height,
+        &src_format,
+        input_data,
+        &dst_format,
+        output_data,
+    )?;
+
+    save_buffer(output_buffer, output_path, width, 3 * height)?;
+    dealloc_buffer(input_buffer, src_size);
+    dealloc_buffer(output_buffer, dst_size);
+
+    Ok(elapsed)
+}
+
+fn i420_bgra(
+    output_path: &str,
+    width: usize,
+    height: usize,
+    source: &[u8],
+) -> BenchmarkResult<Duration> {
+    let src_size = 3 * width * height / 2;
+    let dst_size = 4 * width * height;
+
+    let input_buffer = alloc_buffer(src_size, false);
+    load_buffer(input_buffer, source, false)?;
+
+    let output_buffer = alloc_buffer(dst_size, true);
+
+    let y_plane_size = width * height;
+    let u_plane_size = y_plane_size / 4;
     let input_data: &[&[u8]] = &[
         &input_buffer[0..y_plane_size],
         &input_buffer[y_plane_size..(y_plane_size + u_plane_size)],
@@ -435,56 +443,48 @@ fn i420_bgra(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
         color_space: ColorSpace::Bt601,
         num_planes: 3,
     };
-
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
         color_space: ColorSpace::Lrgb,
         num_planes: 1,
     };
 
-    let start = Instant::now();
-    convert_image(
+    let elapsed = convert_buffer(
         width,
         height,
         &src_format,
-        None,
         input_data,
         &dst_format,
-        None,
         output_data,
     )?;
 
-    let elapsed = start.elapsed();
-
-    // Write to file
-    if !Path::new(output_path).exists() {
-        let mut buffer = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(output_path)?;
-        write!(buffer, "P5\n{} {}\n255\n", 4 * width, height)?;
-        buffer.write_all(&output_buffer)?;
-    }
+    save_buffer(output_buffer, output_path, 4 * width, height)?;
+    dealloc_buffer(input_buffer, src_size);
+    dealloc_buffer(output_buffer, dst_size);
 
     Ok(elapsed)
 }
 
-fn i444_bgra(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResult<Duration> {
-    let (width, mut height, input_buffer) = { pnm_data(input_file)? };
-    height /= 3;
+fn i444_bgra(
+    output_path: &str,
+    width: usize,
+    height: usize,
+    source: &[u8],
+) -> BenchmarkResult<Duration> {
+    let src_size = 3 * width * height;
+    let dst_size = 4 * width * height;
 
-    // Allocate output
-    let dst_size: usize = 4 * (width as usize) * (height as usize);
-    let mut output_buffer: Vec<u8> = vec![0; dst_size];
-    for i in (0..dst_size).step_by(PAGE_SIZE) {
-        output_buffer[i] = 0;
-    }
+    let input_buffer = alloc_buffer(src_size, false);
+    load_buffer(input_buffer, source, false)?;
 
-    let y_size = (width as usize) * (height as usize);
+    let output_buffer = alloc_buffer(dst_size, true);
+
+    let y_plane_size = width * height;
+    let u_plane_size = y_plane_size;
     let input_data: &[&[u8]] = &[
-        &input_buffer[0..y_size],
-        &input_buffer[y_size..(2 * y_size)],
-        &input_buffer[(2 * y_size)..],
+        &input_buffer[0..y_plane_size],
+        &input_buffer[y_plane_size..(y_plane_size + u_plane_size)],
+        &input_buffer[(y_plane_size + u_plane_size)..],
     ];
     let output_data: &mut [&mut [u8]] = &mut [&mut output_buffer[..]];
 
@@ -493,232 +493,280 @@ fn i444_bgra(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
         color_space: ColorSpace::Bt601,
         num_planes: 3,
     };
-
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
         color_space: ColorSpace::Lrgb,
         num_planes: 1,
     };
 
-    let start = Instant::now();
-    convert_image(
+    let elapsed = convert_buffer(
         width,
         height,
         &src_format,
-        None,
         input_data,
         &dst_format,
-        None,
         output_data,
     )?;
 
-    let elapsed = start.elapsed();
-
-    // Write to file
-    if !Path::new(output_path).exists() {
-        let mut buffer = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(output_path)?;
-        write!(buffer, "P5\n{} {}\n255\n", 4 * width, height)?;
-        buffer.write_all(&output_buffer)?;
-    }
+    save_buffer(output_buffer, output_path, 4 * width, height)?;
+    dealloc_buffer(input_buffer, src_size);
+    dealloc_buffer(output_buffer, dst_size);
 
     Ok(elapsed)
 }
 
-fn bench(c: &mut Criterion) {
+fn bgra_rgb(output_path: &str, width: usize, height: usize) -> BenchmarkResult<Duration> {
+    let src_size = 4 * width * height;
+    let dst_size = 3 * width * height;
+
+    let input_buffer = alloc_buffer(src_size, false);
+    load_buffer(input_buffer, BGRA_INPUT, true)?;
+
+    let output_buffer = alloc_buffer(dst_size, true);
+
+    let input_data: &[&[u8]] = &[&input_buffer];
+    let output_data: &mut [&mut [u8]] = &mut [&mut output_buffer[..]];
+
+    let src_format = ImageFormat {
+        pixel_format: PixelFormat::Bgra,
+        color_space: ColorSpace::Lrgb,
+        num_planes: 1,
+    };
+    let dst_format = ImageFormat {
+        pixel_format: PixelFormat::Rgb,
+        color_space: ColorSpace::Lrgb,
+        num_planes: 1,
+    };
+
+    let elapsed = convert_buffer(
+        width,
+        height,
+        &src_format,
+        input_data,
+        &dst_format,
+        output_data,
+    )?;
+
+    save_buffer(output_buffer, output_path, 3 * width, height)?;
+    dealloc_buffer(input_buffer, src_size);
+    dealloc_buffer(output_buffer, dst_size);
+
+    Ok(elapsed)
+}
+
+fn rgb_bgra(output_path: &str, width: usize, height: usize) -> BenchmarkResult<Duration> {
+    let src_size = 3 * width * height;
+    let dst_size = 4 * width * height;
+
+    let input_buffer = alloc_buffer(src_size, false);
+    load_buffer(input_buffer, RGB_INPUT, true)?;
+
+    let output_buffer = alloc_buffer(dst_size, true);
+
+    let input_data: &[&[u8]] = &[&input_buffer];
+    let output_data: &mut [&mut [u8]] = &mut [&mut output_buffer[..]];
+
+    let src_format = ImageFormat {
+        pixel_format: PixelFormat::Rgb,
+        color_space: ColorSpace::Lrgb,
+        num_planes: 1,
+    };
+    let dst_format = ImageFormat {
+        pixel_format: PixelFormat::Bgra,
+        color_space: ColorSpace::Lrgb,
+        num_planes: 1,
+    };
+
+    let elapsed = convert_buffer(
+        width,
+        height,
+        &src_format,
+        input_data,
+        &dst_format,
+        output_data,
+    )?;
+
+    save_buffer(output_buffer, output_path, 4 * width, height)?;
+    dealloc_buffer(input_buffer, src_size);
+    dealloc_buffer(output_buffer, dst_size);
+
+    Ok(elapsed)
+}
+
+fn configure_process() {
+    let cores: Vec<usize> = (0..1).collect();
+
+    set_process_affinity(&cores).unwrap();
+    set_current_thread_priority(ThreadPriority::Max).unwrap();
+}
+
+fn convert_to(
+    group: &mut BenchmarkGroup<measurement::WallTime>,
+    name: &str,
+    input: &BenchmarkInput,
+    output_path: &str,
+    func: Converter,
+) {
+    if Path::new(output_path).exists() {
+        remove_file(Path::new(output_path)).expect("Unable to delete benchmark output");
+    }
+
+    group.bench_with_input(BenchmarkId::new(name, input.name), input, |b, i| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::new(0, 0);
+            for _i in 0..iters {
+                total += func(output_path, i.width, i.height).expect("Benchmark iteration failed");
+            }
+
+            total
+        });
+    });
+}
+
+fn convert_from_to(
+    group: &mut BenchmarkGroup<measurement::WallTime>,
+    name: &str,
+    input: &BenchmarkInput,
+    output_path: &str,
+    input_func: InputConverter,
+    output_func: OutputConverter,
+    num: u64,
+    den: u64,
+) {
+    if Path::new(output_path).exists() {
+        remove_file(Path::new(output_path)).expect("Unable to delete benchmark output");
+    }
+
+    let src_size = input.width * input.height * (num as usize) / (den as usize);
+    let src_data = alloc_buffer(src_size, false);
+
+    input_func(input.width, input.height, src_data).expect("Benchmark iteration failed");
+
+    group.throughput(Throughput::Bytes(src_size as u64));
+    group.bench_with_input(BenchmarkId::new(name, input.name), input, |b, i| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::new(0, 0);
+            for _i in 0..iters {
+                total += output_func(output_path, i.width, i.height, src_data)
+                    .expect("Benchmark iteration failed");
+            }
+
+            total
+        });
+    });
+
+    dealloc_buffer(src_data, src_size);
+}
+
+fn from_bgra(c: &mut Criterion) {
+    configure_process();
     initialize();
 
-    let mut group = c.benchmark_group("dcv-color-primitives");
-    group.sample_size(SAMPLE_SIZE);
+    let mut group = c.benchmark_group("bgra");
 
-    {
-        let output_path = &NV12_OUTPUT;
-        if Path::new(output_path).exists() {
-            remove_file(Path::new(output_path)).expect("Unable to delete benchmark output");
-        }
+    group
+        .sample_size(SAMPLE_SIZE)
+        .warm_up_time(Duration::from_millis(64))
+        .sampling_mode(SamplingMode::Flat);
 
-        let mut input_file: Cursor<&[u8]> = Cursor::new(include_bytes!("input.bgra"));
-        let (width, height) =
-            { pnm_size(&mut input_file).expect("Malformed benchmark input file") };
-        group.throughput(Throughput::Elements((width as u64) * (height as u64)));
-        group.bench_function("bgra>nv12", move |b| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::new(0, 0);
-                for _i in 0..iters {
-                    total += bgra_nv12(&mut input_file, output_path)
-                        .expect("Benchmark iteration failed");
-                }
+    for input in INPUTS {
+        group.throughput(Throughput::Bytes(
+            4 * (input.width as u64) * (input.height as u64),
+        ));
 
-                total
-            });
-        });
-    }
-
-    {
-        let output_path = &BGRA_I420_OUTPUT;
-        if Path::new(output_path).exists() {
-            remove_file(Path::new(output_path)).expect("Unable to delete benchmark output");
-        }
-
-        let mut input_file: Cursor<&[u8]> = Cursor::new(include_bytes!("input.bgra"));
-        let (width, height) =
-            { pnm_size(&mut input_file).expect("Malformed benchmark input file") };
-        group.throughput(Throughput::Elements((width as u64) * (height as u64)));
-        group.bench_function("bgra>i420", move |b| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::new(0, 0);
-                for _i in 0..iters {
-                    total += bgra_i420(&mut input_file, output_path)
-                        .expect("Benchmark iteration failed");
-                }
-
-                total
-            });
-        });
-    }
-
-    {
-        let output_path = &BGRA_I444_OUTPUT;
-        if Path::new(output_path).exists() {
-            remove_file(Path::new(output_path)).expect("Unable to delete benchmark output");
-        }
-
-        let mut input_file: Cursor<&[u8]> = Cursor::new(include_bytes!("input.bgra"));
-        let (width, height) =
-            { pnm_size(&mut input_file).expect("Malformed benchmark input file") };
-        group.throughput(Throughput::Elements((width as u64) * (height as u64)));
-        group.bench_function("bgra>i444", move |b| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::new(0, 0);
-                for _i in 0..iters {
-                    total += bgra_i444(&mut input_file, output_path)
-                        .expect("Benchmark iteration failed");
-                }
-
-                total
-            });
-        });
-    }
-
-    {
-        let output_path = &BGRA_OUTPUT;
-        if Path::new(output_path).exists() {
-            remove_file(Path::new(output_path)).expect("Unable to delete benchmark output");
-        }
-
-        let mut input_file: Cursor<&[u8]> = Cursor::new(include_bytes!("input.nv12"));
-        let (width, height) =
-            { pnm_size(&mut input_file).expect("Malformed benchmark input file") };
-        group.throughput(Throughput::Elements((width as u64) * (height as u64)));
-        group.bench_function("nv12>bgra", move |b| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::new(0, 0);
-                for _i in 0..iters {
-                    total += nv12_bgra(&mut input_file, output_path)
-                        .expect("Benchmark iteration failed");
-                }
-
-                total
-            });
-        });
-    }
-
-    {
-        let output_path = &RGB_BGRA_OUTPUT;
-        if Path::new(output_path).exists() {
-            remove_file(Path::new(output_path)).expect("Unable to delete benchmark output");
-        }
-
-        let mut input_file: Cursor<&[u8]> = Cursor::new(include_bytes!("input.rgb"));
-        let (width, height) =
-            { pnm_size(&mut input_file).expect("Malformed benchmark input file") };
-        group.throughput(Throughput::Elements((width as u64) * (height as u64)));
-        group.bench_function("rgb>bgra", move |b| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::new(0, 0);
-                for _i in 0..iters {
-                    total +=
-                        rgb_bgra(&mut input_file, output_path).expect("Benchmark iteration failed");
-                }
-
-                total
-            });
-        });
-    }
-
-    {
-        let output_path = &BGRA_RGB_OUTPUT;
-        if Path::new(output_path).exists() {
-            remove_file(Path::new(output_path)).expect("Unable to delete benchmark output");
-        }
-
-        let mut input_file: Cursor<&[u8]> = Cursor::new(include_bytes!("input.bgra"));
-        let (width, height) =
-            { pnm_size(&mut input_file).expect("Malformed benchmark input file") };
-        group.throughput(Throughput::Elements((width as u64) * (height as u64)));
-        group.bench_function("bgra>rgb", move |b| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::new(0, 0);
-                for _i in 0..iters {
-                    total +=
-                        bgra_rgb(&mut input_file, output_path).expect("Benchmark iteration failed");
-                }
-
-                total
-            });
-        });
-    }
-
-    {
-        let output_path = &I420_OUTPUT;
-        if Path::new(output_path).exists() {
-            remove_file(Path::new(output_path)).expect("Unable to delete benchmark output");
-        }
-
-        let mut input_file: Cursor<&[u8]> = Cursor::new(include_bytes!("input.i420"));
-        let (width, height) =
-            { pnm_size(&mut input_file).expect("Malformed benchmark input file") };
-        group.throughput(Throughput::Elements((width as u64) * (height as u64)));
-        group.bench_function("i420>bgra", move |b| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::new(0, 0);
-                for _i in 0..iters {
-                    total += i420_bgra(&mut input_file, output_path)
-                        .expect("Benchmark iteration failed");
-                }
-
-                total
-            });
-        });
-    }
-
-    {
-        let output_path = &I444_OUTPUT;
-        if Path::new(output_path).exists() {
-            remove_file(Path::new(output_path)).expect("Unable to delete benchmark output");
-        }
-
-        let mut input_file: Cursor<&[u8]> = Cursor::new(include_bytes!("input.i444"));
-        let (width, height) =
-            { pnm_size(&mut input_file).expect("Malformed benchmark input file") };
-        group.throughput(Throughput::Elements((width as u64) * (height as u64)));
-        group.bench_function("i444>bgra", move |b| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::new(0, 0);
-                for _i in 0..iters {
-                    total += i444_bgra(&mut input_file, output_path)
-                        .expect("Benchmark iteration failed");
-                }
-
-                total
-            });
-        });
+        convert_to(&mut group, "i420", input, BGRA_I420_OUTPUT, bgra_i420);
+        convert_to(&mut group, "i444", input, BGRA_I444_OUTPUT, bgra_i444);
+        convert_to(&mut group, "rgb", input, BGRA_RGB_OUTPUT, bgra_rgb);
     }
 
     group.finish();
 }
 
-criterion_group!(benches, bench);
+fn from_bgr(c: &mut Criterion) {
+    configure_process();
+    initialize();
+
+    let mut group = c.benchmark_group("bgr");
+
+    group
+        .sample_size(SAMPLE_SIZE)
+        .warm_up_time(Duration::from_millis(64))
+        .sampling_mode(SamplingMode::Flat);
+
+    for input in INPUTS {
+        group.throughput(Throughput::Bytes(
+            3 * (input.width as u64) * (input.height as u64),
+        ));
+
+        convert_to(&mut group, "i420", input, BGR_I420_OUTPUT, bgr_i420);
+        convert_to(&mut group, "i444", input, BGR_I444_OUTPUT, bgr_i444);
+        convert_to(&mut group, "bgra", input, RGB_BGRA_OUTPUT, rgb_bgra);
+    }
+
+    group.finish();
+}
+
+fn from_i420(c: &mut Criterion) {
+    configure_process();
+    initialize();
+
+    let mut group = c.benchmark_group("i420");
+
+    group
+        .sample_size(SAMPLE_SIZE)
+        .warm_up_time(Duration::from_millis(64))
+        .sampling_mode(SamplingMode::Flat);
+
+    for input in INPUTS {
+        group.throughput(Throughput::Bytes(
+            3 * (input.width as u64) * (input.height as u64) / 2,
+        ));
+
+        convert_from_to(
+            &mut group,
+            "bgra",
+            input,
+            I420_BGRA_OUTPUT,
+            bgra_i420_input,
+            i420_bgra,
+            3,
+            2,
+        );
+    }
+
+    group.finish();
+}
+
+fn from_i444(c: &mut Criterion) {
+    configure_process();
+    initialize();
+
+    let mut group = c.benchmark_group("i444");
+
+    group
+        .sample_size(SAMPLE_SIZE)
+        .warm_up_time(Duration::from_millis(64))
+        .sampling_mode(SamplingMode::Flat);
+
+    for input in INPUTS {
+        group.throughput(Throughput::Bytes(
+            3 * (input.width as u64) * (input.height as u64),
+        ));
+
+        convert_from_to(
+            &mut group,
+            "bgra",
+            input,
+            I444_BGRA_OUTPUT,
+            bgra_i444_input,
+            i444_bgra,
+            3,
+            1,
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, from_bgra, from_bgr, from_i420, from_i444);
 criterion_main!(benches);

--- a/benches/geninput.py
+++ b/benches/geninput.py
@@ -3,36 +3,13 @@ from array import array
 from itertools import product as cartesian_product
 from random import Random
 from os.path import join, exists, dirname, realpath
-from os import environ
-from fractions import Fraction as frac
 import sys
 
 sys.path.append(dirname(realpath(__file__)))
 
-kr = 0.299
-kg = 0.587
-kb = 0.114
-
-Y_MIN = 16
-Y_MAX = 235
-Y_RANGE = Y_MAX - Y_MIN
-
-C_MIN = 16
-C_MAX = 240
-C_HALF = (C_MAX + C_MIN) >> 1
-C_RANGE = C_MAX - C_MIN
-
-FULL_RANGE = 255
-Y_SCALE = (Y_RANGE / FULL_RANGE)
-C_SCALE = (C_RANGE / FULL_RANGE)
-
 ATLAS_WIDTH = 8192
-
 SHUFFLER = Random(0xDEADBEEF)
 
-def chunks(l, n):
-    for i in range(0, len(l), n):
-        yield l[i:i + n]
 
 if __name__ == '__main__':
     root_dir = dirname(realpath(__file__))
@@ -59,12 +36,14 @@ if __name__ == '__main__':
             color += 1
 
         with open(bgra_input, 'wb') as fn:
-            fn.write(('P5\n%d %d\n255\n' % (ATLAS_WIDTH, height)).encode('utf-8'))
+            fn.write(('P5\n%d %d\n255\n' % (ATLAS_WIDTH, height))
+                     .encode('utf-8'))
+
             BGRA.tofile(fn)
 
     # the same in RGB format
     if not exists(rgb_input):
-        atlas_width = 6144 # 3 * 2048 -> this way width evenly divisible by 3
+        atlas_width = 6144  # 3 * 2048 -> this way width evenly divisible by 3
 
         height = ((3 * len(sample_list)) + (atlas_width - 1)) // atlas_width
         RGB = array('B', [0] * (atlas_width * height))
@@ -77,120 +56,8 @@ if __name__ == '__main__':
             color += 1
 
         with open(rgb_input, 'wb') as fn:
-            fn.write(('P5\n%d %d\n255\n' % (atlas_width, height)).encode('utf-8'))
+            fn.write(('P5\n%d %d\n255\n' % (atlas_width, height))
+                     .encode('utf-8'))
+
             RGB.tofile(fn)
-
-    # write decode input test source
-    decode_input_nv12 = join(root_dir, 'input.nv12')
-    decode_input_i420 = join(root_dir, 'input.i420')
-    decode_input_i444 = join(root_dir, 'input.i444')
-    if not exists(decode_input_nv12) or not exists(decode_input_i420) or not exists(decode_input_i444):
-        frac_kr = frac(int(kr * 10000), 10000)
-        frac_kg = frac(int(kg * 10000), 10000)
-        frac_kb = frac(int(kb * 10000), 10000)
-        frac_S = frac(Y_RANGE, FULL_RANGE)
-        frac_P = frac(C_RANGE, FULL_RANGE)
-        frac_iS = 1 / frac_S
-        frac_ikr = 1 - frac_kr
-        frac_ikb = 1 - frac_kb
-
-        r0 = frac_iS
-        r1 = 2 * frac_ikr / frac_P
-        g0 = (frac_ikr - frac_kb) / (frac_kg * frac_S)
-        g1 = (-2 * frac_ikb * frac_kb) / (frac_kg * frac_P)
-        g2 = (-2 * frac_ikr * frac_kr) / (frac_kg * frac_P)
-        b0 = frac_iS
-        b1 = 2 * frac_ikb / frac_P
-
-        sample_list = []
-        for y in range(1 + Y_RANGE):
-            for cb in range(1 + C_RANGE):
-                b = b0 * y + b1 * cb
-                if -1 < b < 256:
-                    computed_red = r0 * y
-                    computed_green = g0 * y + g1 * cb
-                    for cr in range(1 + C_RANGE):
-                        r = computed_red + r1 * cr
-                        g = computed_green + g2 * cr
-                        if (-1 < r < 256) and (-1 < g < 256):
-                            sample_list.append((y, cb, cr))
-
-        ycbcr_gamut_size = len(sample_list)
-        SHUFFLER.shuffle(sample_list)
-
-        cols = 2 * len(sample_list)
-        height = 2 * ((cols + (ATLAS_WIDTH - 1)) // ATLAS_WIDTH)
-        Y = array('B', [Y_MIN] * (ATLAS_WIDTH * height))
-        CbCr = array('B', [C_HALF] * (ATLAS_WIDTH * height // 2))
-        Cb = array('B', [C_HALF] * (ATLAS_WIDTH * height // 4))
-        Cr = array('B', [C_HALF] * (ATLAS_WIDTH * height // 4))
-        i = 0
-        j = 0
-
-        # half because y has to be repeated
-        for samples in chunks(sample_list, ATLAS_WIDTH // 2):
-            for (y, cb, cr) in samples:
-                y += Y_MIN
-                Y[i] = y
-                Y[i + 1] = y
-                Y[ATLAS_WIDTH + i] = y
-                Y[ATLAS_WIDTH + i + 1] = y
-                CbCr[j] = cb + C_HALF
-                CbCr[j + 1] = cr + C_HALF
-                Cb[j // 2] = cb + C_HALF
-                Cr[j // 2] = cb + C_HALF
-
-                i += 2
-                j += 2
-
-            i += ATLAS_WIDTH
-
-        with open(decode_input_nv12, 'wb') as fn:
-            fn.write(('P5\n%d %d\n255\n' % (ATLAS_WIDTH, height + height // 2)).encode('utf-8'))
-            Y.tofile(fn)
-            CbCr.tofile(fn)
-
-        # i420
-        with open(decode_input_i420, 'wb') as fn:
-            fn.write(('P5\n%d %d\n255\n' % (ATLAS_WIDTH, height + height // 2)).encode('utf-8'))
-            Y.tofile(fn)
-            Cb.tofile(fn)
-            Cr.tofile(fn)
-
-        # i444
-        Y = array('B', [Y_MIN] * (ATLAS_WIDTH * height))
-        Cb = array('B', [C_HALF] * (ATLAS_WIDTH * height))
-        Cr = array('B', [C_HALF] * (ATLAS_WIDTH * height))
-        i = 0
-
-        # half because y has to be repeated
-        for samples in chunks(sample_list, ATLAS_WIDTH // 2):
-            for (y, cb, cr) in samples:
-                y += Y_MIN
-                cb += C_HALF
-                cr += C_HALF
-
-                Y[i] = y
-                Y[i + 1] = y
-                Y[ATLAS_WIDTH + i] = y
-                Y[ATLAS_WIDTH + i + 1] = y
-
-                Cb[i] = cb
-                Cb[i + 1] = cb
-                Cb[ATLAS_WIDTH + i] = cb
-                Cb[ATLAS_WIDTH + i + 1] = cb
-
-                Cr[i] = cr
-                Cr[i + 1] = cr
-                Cr[ATLAS_WIDTH + i] = cr
-                Cr[ATLAS_WIDTH + i + 1] = cr
-
-                i += 2
-            i += ATLAS_WIDTH
-
-        with open(decode_input_i444, 'wb') as fn:
-            fn.write(('P5\n%d %d\n255\n' % (ATLAS_WIDTH, height * 3)).encode('utf-8'))
-            Y.tofile(fn)
-            Cb.tofile(fn)
-            Cr.tofile(fn)
 

--- a/include/dcv_color_primitives.h
+++ b/include/dcv_color_primitives.h
@@ -24,7 +24,7 @@
  *
  * | Source pixel format  | Destination pixel formats  |
  * | -------------------- | -------------------------- |
- * | ARGB                 | I420, I444, NV12           |
+ * | ARGB                 | I420, I444, NV12, RGB      |
  * | BGR                  | I420, I444, NV12           |
  * | BGRA                 | I420, I444, NV12, RGB      |
  * | I420                 | BGRA                       |
@@ -145,7 +145,7 @@
  * }
  * ]|
  *
- * Provide image planes to hangle data scattered in multiple buffers that are not
+ * Provide image planes to handle data scattered in multiple buffers that are not
  * necessarily contiguous:
  *
  * |[<!-- language="C" -->
@@ -642,6 +642,7 @@ DcpResult           dcp_get_buffers_size        (uint32_t              width,
  *   DCP_PIXEL_FORMAT_ARGB             | DCP_PIXEL_FORMAT_I420 [1][algo-1]
  *   DCP_PIXEL_FORMAT_ARGB             | DCP_PIXEL_FORMAT_I444 [1][algo-1]
  *   DCP_PIXEL_FORMAT_ARGB             | DCP_PIXEL_FORMAT_NV12 [1][algo-1]
+ *   DCV_PIXEL_FORMAT_ARGB             | DCP_PIXEL_FORMAT_RGB  [4][algo-4]
  *   DCP_PIXEL_FORMAT_BGRA             | DCP_PIXEL_FORMAT_I420 [1][algo-1]
  *   DCP_PIXEL_FORMAT_BGRA             | DCP_PIXEL_FORMAT_I444 [1][algo-1]
  *   DCP_PIXEL_FORMAT_BGRA             | DCP_PIXEL_FORMAT_NV12 [1][algo-1]
@@ -745,7 +746,7 @@ DcpResult           dcp_get_buffers_size        (uint32_t              width,
  *
  * # Algorithm 4 # {#algo-4}
  *
- * Conversion from BGRA to RGB
+ * Conversion from 32-bit RGB to 24-bit RGB (discards alpha channel)
  */
 DcpResult           dcp_convert_image           (uint32_t               width,
                                                  uint32_t               height,

--- a/src/convert_image/avx2.rs
+++ b/src/convert_image/avx2.rs
@@ -27,29 +27,29 @@ use core::ptr::{read_unaligned as loadu, write_unaligned as storeu};
 #[cfg(target_arch = "x86")]
 use core::arch::x86::{
     __m256i, _mm256_add_epi16, _mm256_add_epi32, _mm256_and_si256, _mm256_cmpeq_epi32,
-    _mm256_extracti128_si256, _mm256_madd_epi16, _mm256_mulhi_epu16, _mm256_or_si256,
-    _mm256_packs_epi32, _mm256_packus_epi16, _mm256_permute2x128_si256, _mm256_permute4x64_epi64,
+    _mm256_madd_epi16, _mm256_mulhi_epu16, _mm256_or_si256, _mm256_packs_epi32,
+    _mm256_packus_epi16, _mm256_permute2x128_si256, _mm256_permute4x64_epi64,
     _mm256_permutevar8x32_epi32, _mm256_set1_epi16, _mm256_set1_epi32, _mm256_set1_epi64x,
-    _mm256_set_epi16, _mm256_set_epi32, _mm256_set_epi64x, _mm256_set_m128i, _mm256_setr_epi32,
-    _mm256_setr_epi8, _mm256_setzero_si256, _mm256_shuffle_epi8, _mm256_slli_epi16,
-    _mm256_slli_epi32, _mm256_srai_epi16, _mm256_srai_epi32, _mm256_srli_epi16, _mm256_srli_epi32,
-    _mm256_srli_si256, _mm256_sub_epi16, _mm256_unpackhi_epi16, _mm256_unpackhi_epi8,
-    _mm256_unpacklo_epi16, _mm256_unpacklo_epi32, _mm256_unpacklo_epi64, _mm256_unpacklo_epi8,
-    _mm_prefetch, _mm_setzero_si128, _MM_HINT_NTA,
+    _mm256_set_epi32, _mm256_set_epi64x, _mm256_set_m128i, _mm256_setr_epi32, _mm256_setr_epi8,
+    _mm256_setzero_si256, _mm256_shuffle_epi8, _mm256_slli_epi16, _mm256_slli_epi32,
+    _mm256_srai_epi16, _mm256_srai_epi32, _mm256_srli_epi16, _mm256_srli_epi32, _mm256_srli_si256,
+    _mm256_sub_epi16, _mm256_unpackhi_epi16, _mm256_unpackhi_epi8, _mm256_unpacklo_epi16,
+    _mm256_unpacklo_epi32, _mm256_unpacklo_epi64, _mm256_unpacklo_epi8, _mm_prefetch,
+    _mm_setzero_si128, _MM_HINT_NTA,
 };
 
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{
     __m256i, _mm256_add_epi16, _mm256_add_epi32, _mm256_and_si256, _mm256_cmpeq_epi32,
-    _mm256_extract_epi64, _mm256_extracti128_si256, _mm256_madd_epi16, _mm256_mulhi_epu16,
-    _mm256_or_si256, _mm256_packs_epi32, _mm256_packus_epi16, _mm256_permute2x128_si256,
-    _mm256_permute4x64_epi64, _mm256_permutevar8x32_epi32, _mm256_set1_epi16, _mm256_set1_epi32,
-    _mm256_set1_epi64x, _mm256_set_epi32, _mm256_set_epi64x, _mm256_set_m128i, _mm256_setr_epi32,
-    _mm256_setr_epi8, _mm256_setzero_si256, _mm256_shuffle_epi8, _mm256_slli_epi16,
-    _mm256_slli_epi32, _mm256_srai_epi16, _mm256_srai_epi32, _mm256_srli_epi16, _mm256_srli_epi32,
-    _mm256_srli_si256, _mm256_sub_epi16, _mm256_unpackhi_epi16, _mm256_unpackhi_epi8,
-    _mm256_unpacklo_epi16, _mm256_unpacklo_epi32, _mm256_unpacklo_epi64, _mm256_unpacklo_epi8,
-    _mm_prefetch, _mm_setzero_si128, _MM_HINT_NTA,
+    _mm256_extract_epi64, _mm256_madd_epi16, _mm256_mulhi_epu16, _mm256_or_si256,
+    _mm256_packs_epi32, _mm256_packus_epi16, _mm256_permute2x128_si256,
+    _mm256_permutevar8x32_epi32, _mm256_set1_epi16, _mm256_set1_epi32, _mm256_set1_epi64x,
+    _mm256_set_epi32, _mm256_set_epi64x, _mm256_set_m128i, _mm256_setr_epi32, _mm256_setr_epi8,
+    _mm256_setzero_si256, _mm256_shuffle_epi8, _mm256_slli_epi16, _mm256_slli_epi32,
+    _mm256_srai_epi16, _mm256_srai_epi32, _mm256_srli_epi16, _mm256_srli_epi32, _mm256_srli_si256,
+    _mm256_sub_epi16, _mm256_unpackhi_epi16, _mm256_unpackhi_epi8, _mm256_unpacklo_epi16,
+    _mm256_unpacklo_epi32, _mm256_unpacklo_epi64, _mm256_unpacklo_epi8, _mm_prefetch,
+    _mm_setzero_si128, _MM_HINT_NTA,
 };
 
 const LANE_COUNT: usize = 32;
@@ -187,9 +187,10 @@ macro_rules! fix_to_i16_16x {
 
 #[cfg(target_arch = "x86")]
 #[inline(always)]
-unsafe fn _mm256_extract_epi64(a: __m256i, index: i32) -> i64 {
+unsafe fn _mm256_extract_epi64(a: __m256i, index: usize) -> i64 {
     let slice = std::mem::transmute::<__m256i, [i64; 4]>(a);
-    return slice[index as usize];
+
+    slice[index]
 }
 
 /// Convert short to 2D short vector (16-wide)

--- a/src/convert_image/common.rs
+++ b/src/convert_image/common.rs
@@ -178,8 +178,3 @@ pub enum Colorimetry {
     Bt709FR,
     Length,
 }
-
-pub enum PixelFormatChannels {
-    Three = 3,
-    Four = 4,
-}

--- a/src/convert_image/sse2.rs
+++ b/src/convert_image/sse2.rs
@@ -1854,3 +1854,25 @@ pub fn bgra_lrgb_rgb_lrgb(
         dst_buffers,
     )
 }
+
+pub fn argb_lrgb_rgb_lrgb(
+    width: u32,
+    height: u32,
+    last_src_plane: u32,
+    src_strides: &[usize],
+    src_buffers: &[&[u8]],
+    last_dst_plane: u32,
+    dst_strides: &[usize],
+    dst_buffers: &mut [&mut [u8]],
+) -> bool {
+    x86::argb_lrgb_rgb_lrgb(
+        width,
+        height,
+        last_src_plane,
+        src_strides,
+        src_buffers,
+        last_dst_plane,
+        dst_strides,
+        dst_buffers,
+    )
+}

--- a/src/convert_image/sse2.rs
+++ b/src/convert_image/sse2.rs
@@ -17,6 +17,7 @@
 #![allow(clippy::wildcard_imports)] // We are importing everything
 use crate::convert_image::common::*;
 use crate::convert_image::x86;
+use crate::{rgb_to_yuv_converter, yuv_to_rgb_converter};
 
 use core::ptr::{read_unaligned as loadu, write_unaligned as storeu};
 
@@ -1077,11 +1078,12 @@ fn nv12_bgra_lrgb(
     last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
     colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1174,13 +1176,15 @@ fn nv12_bgra_lrgb(
 fn i420_bgra_lrgb(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
     colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1277,13 +1281,15 @@ fn i420_bgra_lrgb(
 fn i444_bgra_lrgb(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
     colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1376,11 +1382,12 @@ fn i444_bgra_lrgb(
 fn lrgb_i444(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    channels: PixelFormatChannels,
     colorimetry: usize,
     sampler: Sampler,
 ) -> bool {
@@ -1400,7 +1407,10 @@ fn lrgb_i444(
 
     let w = width as usize;
     let h = height as usize;
-    let depth = channels as usize;
+    let depth = match sampler {
+        Sampler::Bgr => 3_usize,
+        _ => 4_usize,
+    };
     let rgb_stride = depth * w;
 
     // Compute actual strides
@@ -1475,11 +1485,12 @@ fn lrgb_i444(
 fn lrgb_i420(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    channels: PixelFormatChannels,
     colorimetry: usize,
     sampler: Sampler,
 ) -> bool {
@@ -1501,7 +1512,10 @@ fn lrgb_i420(
     let h = height as usize;
     let cw = w / 2;
     let ch = h / 2;
-    let depth = channels as usize;
+    let depth = match sampler {
+        Sampler::Bgr => 3_usize,
+        _ => 4_usize,
+    };
     let rgb_stride = depth * w;
 
     // Compute actual strides
@@ -1580,12 +1594,12 @@ fn lrgb_i420(
 fn lrgb_nv12(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
     last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    channels: PixelFormatChannels,
     colorimetry: usize,
     sampler: Sampler,
 ) -> bool {
@@ -1606,7 +1620,10 @@ fn lrgb_nv12(
     let w = width as usize;
     let h = height as usize;
     let ch = h / 2;
-    let depth = channels as usize;
+    let depth = match sampler {
+        Sampler::Bgr => 3_usize,
+        _ => 4_usize,
+    };
     let rgb_stride = depth * w;
 
     // Compute actual strides
@@ -1683,193 +1700,54 @@ fn lrgb_nv12(
     true
 }
 
-pub fn argb_lrgb_nv12_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn argb_lrgb_nv12_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_nv12_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgra_lrgb_nv12_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_nv12_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn bgr_lrgb_nv12_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn nv12_bt601_bgra_lrgb(
-    width: u32,
-    height: u32,
-    last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    nv12_bgra_lrgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601 as usize,
-    )
-}
-
-pub fn nv12_bt709_bgra_lrgb(
-    width: u32,
-    height: u32,
-    last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    nv12_bgra_lrgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709 as usize,
-    )
-}
+rgb_to_yuv_converter!(Argb, I420, Bt601);
+rgb_to_yuv_converter!(Argb, I420, Bt601FR);
+rgb_to_yuv_converter!(Argb, I420, Bt709);
+rgb_to_yuv_converter!(Argb, I420, Bt709FR);
+rgb_to_yuv_converter!(Argb, I444, Bt601);
+rgb_to_yuv_converter!(Argb, I444, Bt601FR);
+rgb_to_yuv_converter!(Argb, I444, Bt709);
+rgb_to_yuv_converter!(Argb, I444, Bt709FR);
+rgb_to_yuv_converter!(Argb, Nv12, Bt601);
+rgb_to_yuv_converter!(Argb, Nv12, Bt601FR);
+rgb_to_yuv_converter!(Argb, Nv12, Bt709);
+rgb_to_yuv_converter!(Argb, Nv12, Bt709FR);
+rgb_to_yuv_converter!(Bgr, I420, Bt601);
+rgb_to_yuv_converter!(Bgr, I420, Bt601FR);
+rgb_to_yuv_converter!(Bgr, I420, Bt709);
+rgb_to_yuv_converter!(Bgr, I420, Bt709FR);
+rgb_to_yuv_converter!(Bgr, I444, Bt601);
+rgb_to_yuv_converter!(Bgr, I444, Bt601FR);
+rgb_to_yuv_converter!(Bgr, I444, Bt709);
+rgb_to_yuv_converter!(Bgr, I444, Bt709FR);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt601);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt601FR);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt709);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt709FR);
+rgb_to_yuv_converter!(Bgra, I420, Bt601);
+rgb_to_yuv_converter!(Bgra, I420, Bt601FR);
+rgb_to_yuv_converter!(Bgra, I420, Bt709);
+rgb_to_yuv_converter!(Bgra, I420, Bt709FR);
+rgb_to_yuv_converter!(Bgra, I444, Bt601);
+rgb_to_yuv_converter!(Bgra, I444, Bt601FR);
+rgb_to_yuv_converter!(Bgra, I444, Bt709);
+rgb_to_yuv_converter!(Bgra, I444, Bt709FR);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt601);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt601FR);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt709);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt709FR);
+yuv_to_rgb_converter!(I420, Bt601);
+yuv_to_rgb_converter!(I420, Bt601FR);
+yuv_to_rgb_converter!(I420, Bt709);
+yuv_to_rgb_converter!(I420, Bt709FR);
+yuv_to_rgb_converter!(I444, Bt601);
+yuv_to_rgb_converter!(I444, Bt601FR);
+yuv_to_rgb_converter!(I444, Bt709);
+yuv_to_rgb_converter!(I444, Bt709FR);
+yuv_to_rgb_converter!(Nv12, Bt601);
+yuv_to_rgb_converter!(Nv12, Bt601FR);
+yuv_to_rgb_converter!(Nv12, Bt709);
+yuv_to_rgb_converter!(Nv12, Bt709FR);
 
 pub fn rgb_lrgb_bgra_lrgb(
     width: u32,
@@ -1881,8 +1759,8 @@ pub fn rgb_lrgb_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    const SRC_DEPTH: usize = PixelFormatChannels::Three as usize;
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const SRC_DEPTH: usize = 3;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1955,366 +1833,6 @@ pub fn rgb_lrgb_bgra_lrgb(
     true
 }
 
-pub fn i420_bt601_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i420_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601 as usize,
-    )
-}
-
-pub fn i420_bt709_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i420_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709 as usize,
-    )
-}
-
-pub fn i444_bt601_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601 as usize,
-    )
-}
-
-pub fn i444_bt709_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709 as usize,
-    )
-}
-
-pub fn argb_lrgb_i420_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn argb_lrgb_i420_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i420_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgra_lrgb_i420_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i420_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn bgr_lrgb_i420_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn argb_lrgb_i444_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn argb_lrgb_i444_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i444_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgra_lrgb_i444_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i444_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn bgr_lrgb_i444_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgr,
-    )
-}
-
 pub fn bgra_lrgb_rgb_lrgb(
     width: u32,
     height: u32,
@@ -2334,553 +1852,5 @@ pub fn bgra_lrgb_rgb_lrgb(
         last_dst_plane,
         dst_strides,
         dst_buffers,
-    )
-}
-
-pub fn argb_lrgb_nv12_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_nv12_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_nv12_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn nv12_bt601fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    nv12_bgra_lrgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601FR as usize,
-    )
-}
-
-pub fn i420_bt601fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i420_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601FR as usize,
-    )
-}
-
-pub fn i444_bt601fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601FR as usize,
-    )
-}
-
-pub fn argb_lrgb_i420_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i420_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i420_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn argb_lrgb_i444_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i444_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i444_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn argb_lrgb_nv12_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_nv12_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_nv12_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn nv12_bt709fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    nv12_bgra_lrgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709FR as usize,
-    )
-}
-
-pub fn i420_bt709fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i420_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709FR as usize,
-    )
-}
-
-pub fn i444_bt709fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709FR as usize,
-    )
-}
-
-pub fn argb_lrgb_i420_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i420_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i420_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn argb_lrgb_i444_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i444_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i444_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgr,
     )
 }

--- a/src/convert_image/x86.rs
+++ b/src/convert_image/x86.rs
@@ -16,6 +16,7 @@
 
 #![allow(clippy::wildcard_imports)] // We are importing everything
 use crate::convert_image::common::*;
+use crate::{rgb_to_yuv_converter, yuv_to_rgb_converter};
 
 use core::ptr::{read_unaligned as loadu, write_unaligned as storeu};
 
@@ -845,11 +846,12 @@ fn nv12_bgra_lrgb(
     last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
     colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -914,13 +916,15 @@ fn nv12_bgra_lrgb(
 fn i420_bgra_lrgb(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
     colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -980,13 +984,15 @@ fn i420_bgra_lrgb(
 fn i444_bgra_lrgb(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
     colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1043,11 +1049,12 @@ fn i444_bgra_lrgb(
 fn lrgb_i444(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    channels: PixelFormatChannels,
     colorimetry: usize,
     sampler: Sampler,
 ) -> bool {
@@ -1067,7 +1074,10 @@ fn lrgb_i444(
 
     let w = width as usize;
     let h = height as usize;
-    let depth = channels as usize;
+    let depth = match sampler {
+        Sampler::Bgr => 3_usize,
+        _ => 4_usize,
+    };
     let rgb_stride = depth * w;
 
     // Compute actual strides
@@ -1111,11 +1121,12 @@ fn lrgb_i444(
 fn lrgb_i420(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    channels: PixelFormatChannels,
     colorimetry: usize,
     sampler: Sampler,
 ) -> bool {
@@ -1137,7 +1148,10 @@ fn lrgb_i420(
     let h = height as usize;
     let cw = w / 2;
     let ch = h / 2;
-    let depth = channels as usize;
+    let depth = match sampler {
+        Sampler::Bgr => 3_usize,
+        _ => 4_usize,
+    };
     let rgb_stride = depth * w;
 
     // Compute actual strides
@@ -1181,12 +1195,12 @@ fn lrgb_i420(
 fn lrgb_nv12(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
     last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    channels: PixelFormatChannels,
     colorimetry: usize,
     sampler: Sampler,
 ) -> bool {
@@ -1207,7 +1221,10 @@ fn lrgb_nv12(
     let w = width as usize;
     let h = height as usize;
     let ch = h / 2;
-    let depth = channels as usize;
+    let depth = match sampler {
+        Sampler::Bgr => 3_usize,
+        _ => 4_usize,
+    };
     let rgb_stride = depth * w;
 
     // Compute actual strides
@@ -1254,6 +1271,55 @@ fn lrgb_nv12(
     true
 }
 
+rgb_to_yuv_converter!(Argb, I420, Bt601);
+rgb_to_yuv_converter!(Argb, I420, Bt601FR);
+rgb_to_yuv_converter!(Argb, I420, Bt709);
+rgb_to_yuv_converter!(Argb, I420, Bt709FR);
+rgb_to_yuv_converter!(Argb, I444, Bt601);
+rgb_to_yuv_converter!(Argb, I444, Bt601FR);
+rgb_to_yuv_converter!(Argb, I444, Bt709);
+rgb_to_yuv_converter!(Argb, I444, Bt709FR);
+rgb_to_yuv_converter!(Argb, Nv12, Bt601);
+rgb_to_yuv_converter!(Argb, Nv12, Bt601FR);
+rgb_to_yuv_converter!(Argb, Nv12, Bt709);
+rgb_to_yuv_converter!(Argb, Nv12, Bt709FR);
+rgb_to_yuv_converter!(Bgr, I420, Bt601);
+rgb_to_yuv_converter!(Bgr, I420, Bt601FR);
+rgb_to_yuv_converter!(Bgr, I420, Bt709);
+rgb_to_yuv_converter!(Bgr, I420, Bt709FR);
+rgb_to_yuv_converter!(Bgr, I444, Bt601);
+rgb_to_yuv_converter!(Bgr, I444, Bt601FR);
+rgb_to_yuv_converter!(Bgr, I444, Bt709);
+rgb_to_yuv_converter!(Bgr, I444, Bt709FR);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt601);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt601FR);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt709);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt709FR);
+rgb_to_yuv_converter!(Bgra, I420, Bt601);
+rgb_to_yuv_converter!(Bgra, I420, Bt601FR);
+rgb_to_yuv_converter!(Bgra, I420, Bt709);
+rgb_to_yuv_converter!(Bgra, I420, Bt709FR);
+rgb_to_yuv_converter!(Bgra, I444, Bt601);
+rgb_to_yuv_converter!(Bgra, I444, Bt601FR);
+rgb_to_yuv_converter!(Bgra, I444, Bt709);
+rgb_to_yuv_converter!(Bgra, I444, Bt709FR);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt601);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt601FR);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt709);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt709FR);
+yuv_to_rgb_converter!(I420, Bt601);
+yuv_to_rgb_converter!(I420, Bt601FR);
+yuv_to_rgb_converter!(I420, Bt709);
+yuv_to_rgb_converter!(I420, Bt709FR);
+yuv_to_rgb_converter!(I444, Bt601);
+yuv_to_rgb_converter!(I444, Bt601FR);
+yuv_to_rgb_converter!(I444, Bt709);
+yuv_to_rgb_converter!(I444, Bt709FR);
+yuv_to_rgb_converter!(Nv12, Bt601);
+yuv_to_rgb_converter!(Nv12, Bt601FR);
+yuv_to_rgb_converter!(Nv12, Bt709);
+yuv_to_rgb_converter!(Nv12, Bt709FR);
+
 pub fn rgb_lrgb_bgra_lrgb(
     width: u32,
     height: u32,
@@ -1264,8 +1330,8 @@ pub fn rgb_lrgb_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    const SRC_DEPTH: usize = PixelFormatChannels::Three as usize;
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const SRC_DEPTH: usize = 3;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1303,554 +1369,6 @@ pub fn rgb_lrgb_bgra_lrgb(
     true
 }
 
-pub fn argb_lrgb_nv12_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn argb_lrgb_nv12_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_nv12_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgra_lrgb_nv12_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_nv12_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn bgr_lrgb_nv12_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn nv12_bt601_bgra_lrgb(
-    width: u32,
-    height: u32,
-    last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    nv12_bgra_lrgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601 as usize,
-    )
-}
-
-pub fn nv12_bt709_bgra_lrgb(
-    width: u32,
-    height: u32,
-    last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    nv12_bgra_lrgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709 as usize,
-    )
-}
-
-pub fn i420_bt601_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i420_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601 as usize,
-    )
-}
-
-pub fn i420_bt709_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i420_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709 as usize,
-    )
-}
-
-pub fn i444_bt601_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601 as usize,
-    )
-}
-
-pub fn i444_bt709_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709 as usize,
-    )
-}
-
-pub fn argb_lrgb_i420_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn argb_lrgb_i420_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i420_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgra_lrgb_i420_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i420_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn bgr_lrgb_i420_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn argb_lrgb_i444_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn argb_lrgb_i444_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i444_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgra_lrgb_i444_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i444_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn bgr_lrgb_i444_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgr,
-    )
-}
-
 pub fn bgra_lrgb_rgb_lrgb(
     width: u32,
     height: u32,
@@ -1861,8 +1379,8 @@ pub fn bgra_lrgb_rgb_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    const SRC_DEPTH: usize = PixelFormatChannels::Four as usize;
-    const DST_DEPTH: usize = PixelFormatChannels::Three as usize;
+    const SRC_DEPTH: usize = 4;
+    const DST_DEPTH: usize = 3;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1898,552 +1416,4 @@ pub fn bgra_lrgb_rgb_lrgb(
     bgra_to_rgb(w, h, src_stride, src_buffer, dst_stride, dst_buffer);
 
     true
-}
-
-pub fn argb_lrgb_nv12_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_nv12_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_nv12_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn nv12_bt601fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    nv12_bgra_lrgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601FR as usize,
-    )
-}
-
-pub fn i420_bt601fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i420_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601FR as usize,
-    )
-}
-
-pub fn i444_bt601fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601FR as usize,
-    )
-}
-
-pub fn argb_lrgb_i420_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i420_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i420_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn argb_lrgb_i444_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i444_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i444_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn argb_lrgb_nv12_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_nv12_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_nv12_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn nv12_bt709fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    nv12_bgra_lrgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709FR as usize,
-    )
-}
-
-pub fn i420_bt709fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i420_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709FR as usize,
-    )
-}
-
-pub fn i444_bt709fr_bgra_lrgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_lrgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709FR as usize,
-    )
-}
-
-pub fn argb_lrgb_i420_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i420_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i420_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn argb_lrgb_i444_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i444_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i444_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgr,
-    )
 }

--- a/src/convert_image/x86.rs
+++ b/src/convert_image/x86.rs
@@ -49,7 +49,16 @@ fn _bswap(x: i32) -> i32 {
 
 #[cfg(not(target_arch = "x86_64"))]
 unsafe fn _bswap64(x: i64) -> i64 {
-    (((_bswap(x as i32) as u64) << 32) | ((_bswap((x >> 32) as i32) as u64) & 0xFFFFFFFF)) as i64
+    // Checked: we want to reinterpret the bits
+    #[allow(
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation
+    )]
+    {
+        (((_bswap(x as i32) as u64) << 32) | ((_bswap((x >> 32) as i32) as u64) & 0xFFFF_FFFF))
+            as i64
+    }
 }
 
 pub const FORWARD_WEIGHTS: [[i32; 11]; Colorimetry::Length as usize] = [

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -17,6 +17,69 @@ use crate::color_space::ColorSpace;
 use crate::pixel_format::PixelFormat;
 use crate::static_assert;
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! rgb_to_yuv_converter {
+    ($src_pf:ident, $dst_pf:ident, $dst_cs:ident) => {
+        paste::paste! {
+            pub fn [<$src_pf:lower _lrgb_ $dst_pf:lower _ $dst_cs:lower>](
+                width: u32,
+                height: u32,
+                last_src_plane: u32,
+                src_strides: &[usize],
+                src_buffers: &[&[u8]],
+                last_dst_plane: u32,
+                dst_strides: &[usize],
+                dst_buffers: &mut [&mut [u8]],
+            ) -> bool {
+                [<lrgb _ $dst_pf:lower>](
+                    width,
+                    height,
+                    last_src_plane as usize,
+                    src_strides,
+                    src_buffers,
+                    last_dst_plane as usize,
+                    dst_strides,
+                    dst_buffers,
+                    Colorimetry::$dst_cs as usize,
+                    Sampler::$src_pf,
+                )
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! yuv_to_rgb_converter {
+    ($src_pf:ident, $src_cs:ident) => {
+        paste::paste! {
+            pub fn [<$src_pf:lower _ $src_cs:lower _bgra_lrgb>] (
+                width: u32,
+                height: u32,
+                last_src_plane: u32,
+                src_strides: &[usize],
+                src_buffers: &[&[u8]],
+                last_dst_plane: u32,
+                dst_strides: &[usize],
+                dst_buffers: &mut [&mut [u8]],
+            ) -> bool {
+                [<$src_pf:lower _bgra_lrgb>](
+                    width,
+                    height,
+                    last_src_plane as usize,
+                    src_strides,
+                    src_buffers,
+                    last_dst_plane as usize,
+                    dst_strides,
+                    dst_buffers,
+                    Colorimetry::$src_cs as usize,
+                )
+            }
+        }
+    };
+}
+
 #[cfg(not(tarpaulin_include))]
 const fn enum_count(lo: u32, hi: u32) -> u32 {
     hi - lo + 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! | Source pixel format  | Destination pixel formats  |
 //! | -------------------- | -------------------------- |
-//! | ARGB                 | I420, I444, NV12           |
+//! | ARGB                 | I420, I444, NV12, RGB      |
 //! | BGR                  | I420, I444, NV12           |
 //! | BGRA                 | I420, I444, NV12, RGB      |
 //! | I420                 | BGRA                       |
@@ -178,7 +178,7 @@
 //! }
 //! ```
 //!
-//! Provide image planes to hangle data scattered in multiple buffers that are not
+//! Provide image planes to handle data scattered in multiple buffers that are not
 //! necessarily contiguous:
 //! ```
 //! use dcv_color_primitives as dcp;
@@ -423,6 +423,7 @@ macro_rules! set_dispatch_table {
         set_dispatcher!($conv, $set, Argb, Lrgb, I444, Bt709);
         set_dispatcher!($conv, $set, Argb, Lrgb, Nv12, Bt601);
         set_dispatcher!($conv, $set, Argb, Lrgb, Nv12, Bt709);
+        set_dispatcher!($conv, $set, Argb, Lrgb, Rgb, Lrgb);
         set_dispatcher!($conv, $set, Bgr, Lrgb, I420, Bt601);
         set_dispatcher!($conv, $set, Bgr, Lrgb, I420, Bt709);
         set_dispatcher!($conv, $set, Bgr, Lrgb, I444, Bt601);
@@ -781,6 +782,7 @@ pub fn get_buffers_size(
 ///   `PixelFormat::Argb`             | `PixelFormat::I420` [`1`]
 ///   `PixelFormat::Argb`             | `PixelFormat::I444` [`1`]
 ///   `PixelFormat::Argb`             | `PixelFormat::Nv12` [`1`]
+///   `PixelFormat::Argb`             | `PixelFormat::Rgb`  [`4`]
 ///   `PixelFormat::Bgra`             | `PixelFormat::I420` [`1`]
 ///   `PixelFormat::Bgra`             | `PixelFormat::I444` [`1`]
 ///   `PixelFormat::Bgra`             | `PixelFormat::Nv12` [`1`]
@@ -870,7 +872,7 @@ pub fn get_buffers_size(
 /// Conversion from RGB to BGRA
 ///
 /// # Algorithm 4
-/// Conversion from BGRA to RGB
+/// Conversion from 32-bit RGB to 24-bit RGB (discards alpha channel)
 ///
 /// [`NotInitialized`]: ./enum.ErrorKind.html#variant.NotInitialized
 /// [`InvalidValue`]: ./enum.ErrorKind.html#variant.InvalidValue
@@ -881,6 +883,7 @@ pub fn get_buffers_size(
 /// [`1`]: ./fn.convert_image.html#algorithm-1
 /// [`2`]: ./fn.convert_image.html#algorithm-2
 /// [`3`]: ./fn.convert_image.html#algorithm-3
+/// [`4`]: ./fn.convert_image.html#algorithm-4
 pub fn convert_image(
     width: u32,
     height: u32,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1263,25 +1263,21 @@ fn lrgb_conversion_ok(src_pixel_format: PixelFormat, dst_pixel_format: PixelForm
                 let input_index = y * src_stride + x * src_depth;
                 let output_index = y * dst_stride + x * dst_depth;
 
-                match dst_pixel_format {
-                    PixelFormat::Rgb => match src_pixel_format {
-                        PixelFormat::Bgra => {
-                            assert_eq!(dst_image[output_index], src_image[input_index + 2]);
-                            assert_eq!(dst_image[output_index + 1], src_image[input_index + 1]);
-                            assert_eq!(dst_image[output_index + 2], src_image[input_index]);
-                        }
-                        _ => {
-                            assert_eq!(dst_image[output_index], src_image[input_index + 1]);
-                            assert_eq!(dst_image[output_index + 1], src_image[input_index + 2]);
-                            assert_eq!(dst_image[output_index + 2], src_image[input_index + 3]);
-                        }
-                    },
-                    _ => {
+                if let PixelFormat::Rgb = dst_pixel_format {
+                    if let PixelFormat::Bgra = src_pixel_format {
                         assert_eq!(dst_image[output_index], src_image[input_index + 2]);
                         assert_eq!(dst_image[output_index + 1], src_image[input_index + 1]);
                         assert_eq!(dst_image[output_index + 2], src_image[input_index]);
-                        assert_eq!(dst_image[output_index + 3], 255);
+                    } else {
+                        assert_eq!(dst_image[output_index], src_image[input_index + 1]);
+                        assert_eq!(dst_image[output_index + 1], src_image[input_index + 2]);
+                        assert_eq!(dst_image[output_index + 2], src_image[input_index + 3]);
                     }
+                } else {
+                    assert_eq!(dst_image[output_index], src_image[input_index + 2]);
+                    assert_eq!(dst_image[output_index + 1], src_image[input_index + 1]);
+                    assert_eq!(dst_image[output_index + 2], src_image[input_index]);
+                    assert_eq!(dst_image[output_index + 3], 255);
                 }
             }
         }


### PR DESCRIPTION
*Description of changes:*
* Greatly simplified the converter functions using the paste! macro
* Simplified bgra to rgb conversion
* Added new conversion: argb to rgb (no byte swap, just alpha removal)
* Added enhanced bgra to rgb conversion using the rust brand new asm! macro
* Improved benchmarks and migrate from cargo bench to cargo criterion

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
