### PR TITLE
Wip/colorspace rename

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcv-color-primitives"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2018"
 description = "a library to perform image color model conversion"
 license = "MIT-0"

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+News in 0.5.0
+-------------
+* Renamed ColorSpace::Lrgb in favor of ColorSpace::Rgb
+  https://github.com/aws/dcv-color-primitives/issues/63
+* Refactor internal conversion functions using the paste! macro
+
 News in 0.4.1
 -------------
 * BGR to RGB conversion

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ fn main() {
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
@@ -287,7 +287,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: NUM_PLANES,
     };
 
@@ -335,7 +335,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: NUM_DST_PLANES,
     };
 
@@ -380,7 +380,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgr,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: NUM_SRC_PLANES,
     };
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -104,7 +104,7 @@ fn bgra_nv12(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
@@ -160,7 +160,7 @@ fn bgra_i420(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
@@ -216,7 +216,7 @@ fn bgra_i444(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
@@ -274,7 +274,7 @@ fn nv12_bgra(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
 
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
@@ -321,13 +321,13 @@ fn bgr_rgb(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResult
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgr,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Rgb,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
@@ -374,13 +374,13 @@ fn rgb_bgra(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResul
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Rgb,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
@@ -427,13 +427,13 @@ fn bgra_rgb(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResul
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Rgb,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
@@ -492,7 +492,7 @@ fn i420_bgra(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
 
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
@@ -550,7 +550,7 @@ fn i444_bgra(input_file: &mut Cursor<&[u8]>, output_path: &str) -> BenchmarkResu
 
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 

--- a/c_tests/unit.c
+++ b/c_tests/unit.c
@@ -583,7 +583,7 @@ convert_image_rgb_to_yuv_size_mode_stride(uint32_t       num_planes,
     DcpStatus status = dcp_status();
     DcpImageFormat src_format = {
         src_pixel_format,
-        DCP_COLOR_SPACE_LRGB,
+        DCP_COLOR_SPACE_RGB,
         1
     };
     DcpImageFormat dst_format = {
@@ -999,7 +999,7 @@ convert_image_yuv_to_rgb_size_mode_stride(uint32_t       num_planes,
 
     DcpImageFormat dst_format = {
         DCP_PIXEL_FORMAT_BGRA,
-        DCP_COLOR_SPACE_LRGB,
+        DCP_COLOR_SPACE_RGB,
         1
     };
 
@@ -1379,7 +1379,7 @@ unit_convert_image_rgb_to_yuv_errors(void)
                         TEST_ASSERT(DCP_RESULT_ERR, DCP_ERROR_KIND_INVALID_VALUE);
 
                         src_pf_rgb = src_pixel_format < DCP_PIXEL_FORMAT_I444;
-                        src_cs_rgb = src_color_space == DCP_COLOR_SPACE_LRGB;
+                        src_cs_rgb = src_color_space == DCP_COLOR_SPACE_RGB;
                         expected = dcp_status();
 
                         SET_EXPECTED(src_pixel_format > DCP_PIXEL_FORMAT_NV12, DCP_ERROR_KIND_INVALID_VALUE);
@@ -1389,7 +1389,7 @@ unit_convert_image_rgb_to_yuv_errors(void)
                         SET_EXPECTED(!src_pf_rgb && src_cs_rgb, DCP_ERROR_KIND_INVALID_VALUE);
                         SET_EXPECTED(src_pf_rgb && !src_cs_rgb, DCP_ERROR_KIND_INVALID_VALUE);
 
-                        SET_EXPECTED(dst_color_space <= DCP_COLOR_SPACE_LRGB, DCP_ERROR_KIND_INVALID_VALUE);
+                        SET_EXPECTED(dst_color_space <= DCP_COLOR_SPACE_RGB, DCP_ERROR_KIND_INVALID_VALUE);
 
                         SET_EXPECTED(is_valid_format(&src_format, width, height) == 0, DCP_ERROR_KIND_INVALID_VALUE);
                         SET_EXPECTED(is_valid_format(&dst_format, width, height) == 0, DCP_ERROR_KIND_INVALID_VALUE);
@@ -1400,7 +1400,7 @@ unit_convert_image_rgb_to_yuv_errors(void)
                                       src_pixel_format != DCP_PIXEL_FORMAT_BGRA &&
                                       src_pixel_format != DCP_PIXEL_FORMAT_BGR), DCP_ERROR_KIND_INVALID_OPERATION);
 
-                        SET_EXPECTED(src_color_space != DCP_COLOR_SPACE_LRGB, DCP_ERROR_KIND_INVALID_OPERATION);
+                        SET_EXPECTED(src_color_space != DCP_COLOR_SPACE_RGB, DCP_ERROR_KIND_INVALID_OPERATION);
 
                         status.result = dcp_convert_image(width, height,
                                                           &src_format, &src_stride, (const uint8_t * const *)&src_buffer,
@@ -1511,14 +1511,14 @@ unit_convert_image_yuv_to_rgb_errors(void)
                         TEST_ASSERT(DCP_RESULT_ERR, DCP_ERROR_KIND_INVALID_VALUE);
 
                         dst_pf_rgb = dst_pixel_format < DCP_PIXEL_FORMAT_I444;
-                        dst_cs_rgb = dst_color_space == DCP_COLOR_SPACE_LRGB;
+                        dst_cs_rgb = dst_color_space == DCP_COLOR_SPACE_RGB;
                         expected = dcp_status();
 
                         SET_EXPECTED(src_color_space > DCP_COLOR_SPACE_BT709FR, DCP_ERROR_KIND_INVALID_VALUE);
                         SET_EXPECTED(dst_pixel_format > DCP_PIXEL_FORMAT_NV12, DCP_ERROR_KIND_INVALID_VALUE);
                         SET_EXPECTED(dst_color_space > DCP_COLOR_SPACE_BT709FR, DCP_ERROR_KIND_INVALID_VALUE);
 
-                        SET_EXPECTED(src_color_space <= DCP_COLOR_SPACE_LRGB, DCP_ERROR_KIND_INVALID_VALUE);
+                        SET_EXPECTED(src_color_space <= DCP_COLOR_SPACE_RGB, DCP_ERROR_KIND_INVALID_VALUE);
 
                         SET_EXPECTED(is_valid_format(&src_format, width, height) == 0, DCP_ERROR_KIND_INVALID_VALUE);
                         SET_EXPECTED(is_valid_format(&dst_format, width, height) == 0, DCP_ERROR_KIND_INVALID_VALUE);
@@ -1529,7 +1529,7 @@ unit_convert_image_yuv_to_rgb_errors(void)
                         SET_EXPECTED(corrupt != 0, DCP_ERROR_KIND_INVALID_VALUE);
 
                         SET_EXPECTED(dst_pixel_format != DCP_PIXEL_FORMAT_BGRA, DCP_ERROR_KIND_INVALID_OPERATION);
-                        SET_EXPECTED(dst_color_space != DCP_COLOR_SPACE_LRGB, DCP_ERROR_KIND_INVALID_OPERATION);
+                        SET_EXPECTED(dst_color_space != DCP_COLOR_SPACE_RGB, DCP_ERROR_KIND_INVALID_OPERATION);
 
                         status.result = dcp_convert_image(width, height,
                                                           &src_format, src_strides, (const uint8_t * const *)src_buffers,
@@ -1678,7 +1678,7 @@ unit_convert_image_over_4gb_limit(void)
 
     DcpImageFormat src_format = {
         DCP_PIXEL_FORMAT_ARGB,
-        DCP_COLOR_SPACE_LRGB,
+        DCP_COLOR_SPACE_RGB,
         1
     };
 
@@ -1740,7 +1740,7 @@ unit_convert_image_over_4gb_limit(void)
 }
 
 static uint8_t
-get_format_bpp_lrgb(DcpPixelFormat format)
+get_format_bpp_rgb(DcpPixelFormat format)
 {
     if (format == DCP_PIXEL_FORMAT_ARGB ||
         format == DCP_PIXEL_FORMAT_BGRA ||
@@ -1752,15 +1752,15 @@ get_format_bpp_lrgb(DcpPixelFormat format)
 }
 
 static void
-unit_image_convert_lrgb_ok(DcpPixelFormat src_pixel_format,
+unit_image_convert_rgb_ok(DcpPixelFormat src_pixel_format,
                            DcpPixelFormat dst_pixel_format)
 {
     const uint32_t MAX_WIDTH = 49;
     const uint32_t MAX_HEIGHT = 8;
     const uint32_t MAX_FILL_BYTES = 2;
     const uint32_t auto_stride = DCP_STRIDE_AUTO;
-    const uint8_t src_bpp = get_format_bpp_lrgb(src_pixel_format);
-    const uint8_t dst_bpp = get_format_bpp_lrgb(dst_pixel_format);;
+    const uint8_t src_bpp = get_format_bpp_rgb(src_pixel_format);
+    const uint8_t dst_bpp = get_format_bpp_rgb(dst_pixel_format);;
 
     uint8_t *src_buffers[1];
     uint8_t *dst_buffers[1];
@@ -1777,13 +1777,13 @@ unit_image_convert_lrgb_ok(DcpPixelFormat src_pixel_format,
 
     DcpImageFormat src_format = {
         src_pixel_format,
-        DCP_COLOR_SPACE_LRGB,
+        DCP_COLOR_SPACE_RGB,
         1
     };
 
     DcpImageFormat dst_format = {
         dst_pixel_format,
-        DCP_COLOR_SPACE_LRGB,
+        DCP_COLOR_SPACE_RGB,
         1
     };
 
@@ -1874,11 +1874,11 @@ main(int   argc,
     } else if (strcmp(test_name, "unit_convert_image_over_4gb_limit") == 0) {
         unit_convert_image_over_4gb_limit();
     } else if (strcmp(test_name, "unit_image_convert_rgb_to_bgra_ok") == 0) {
-        unit_image_convert_lrgb_ok(DCP_PIXEL_FORMAT_RGB, DCP_PIXEL_FORMAT_BGRA);
+        unit_image_convert_rgb_ok(DCP_PIXEL_FORMAT_RGB, DCP_PIXEL_FORMAT_BGRA);
     } else if (strcmp(test_name, "unit_image_convert_bgra_to_rgb_ok") == 0) {
-        unit_image_convert_lrgb_ok(DCP_PIXEL_FORMAT_BGRA, DCP_PIXEL_FORMAT_RGB);
+        unit_image_convert_rgb_ok(DCP_PIXEL_FORMAT_BGRA, DCP_PIXEL_FORMAT_RGB);
     }  else if (strcmp(test_name, "unit_image_convert_bgr_to_rgb_ok") == 0) {
-        unit_image_convert_lrgb_ok(DCP_PIXEL_FORMAT_BGR, DCP_PIXEL_FORMAT_RGB);
+        unit_image_convert_rgb_ok(DCP_PIXEL_FORMAT_BGR, DCP_PIXEL_FORMAT_RGB);
     } else {
         return EXIT_FAILURE;
     }

--- a/include/dcv_color_primitives.h
+++ b/include/dcv_color_primitives.h
@@ -60,7 +60,7 @@
  *
  * DcpImageFormat src_format = {
  *     DCP_PIXEL_FORMAT_BGRA,
- *     DCP_COLOR_SPACE_LRGB,
+ *     DCP_COLOR_SPACE_RGB,
  *     1,
  * };
  *
@@ -91,7 +91,7 @@
  *
  * DcpImageFormat src_format = {
  *     DCP_PIXEL_FORMAT_BGRA,
- *     DCP_COLOR_SPACE_LRGB,
+ *     DCP_COLOR_SPACE_RGB,
  *     1,
  * };
  *
@@ -126,7 +126,7 @@
  *
  * DcpImageFormat format = {
  *     DCP_PIXEL_FORMAT_BGRA,
- *     DCP_COLOR_SPACE_LRGB,
+ *     DCP_COLOR_SPACE_RGB,
  *     NUM_PLANES,
  * };
  *
@@ -162,7 +162,7 @@
  *
  * DcpImageFormat dst_format = {
  *     DCP_PIXEL_FORMAT_BGRA,
- *     DCP_COLOR_SPACE_LRGB,
+ *     DCP_COLOR_SPACE_RGB,
  *     NUM_DST_PLANES,
  * };
  *
@@ -209,7 +209,7 @@
  *
  * DcpImageFormat src_format = {
  *     DCP_PIXEL_FORMAT_BGR,
- *     DCP_COLOR_SPACE_LRGB,
+ *     DCP_COLOR_SPACE_RGB,
  *     NUM_SRC_PLANES,
  * };
  *
@@ -327,11 +327,17 @@ typedef enum {
 
 /**
  * DcpColorSpace:
- * @DCP_COLOR_SPACE_LRGB: Gamma-corrected RGB
+ * @DCP_COLOR_SPACE_RGB: Gamma-corrected R'G'B'.
+ *                       The gamma is the one defined in ITU-R Recommendation BT.709-6 page 3, item 1.2
+ *                       The relationship between gamma-corrected component (C') and its linear value (C)
+ *                       is the following one:
+ *                       C' = 4.5 * C                      if C < 0.018,
+ *                            1.099 * pow(C, 0.45) - 0.099 otherwise.
  * @DCP_COLOR_SPACE_BT601: YCbCr, ITU-R Recommendation BT.601 (standard video system)
  * @DCP_COLOR_SPACE_BT709: YCbCr, ITU-R Recommendation BT.709 (CSC systems)
  * @DCP_COLOR_SPACE_BT601FR: YCbCr, BT.601 (full range)
  * @DCP_COLOR_SPACE_BT709FR: YCbCr, BT.709 (full range)
+ * @DCP_COLOR_SPACE_LRGB: Deprecated: 0.5.0: Use @DCP_COLOR_SPACE_RGB instead
  *
  * An enumeration of supported color models.
  *
@@ -343,11 +349,12 @@ typedef enum {
  * - Primaries
  */
 typedef enum {
-    DCP_COLOR_SPACE_LRGB,
+    DCP_COLOR_SPACE_RGB,
     DCP_COLOR_SPACE_BT601,
     DCP_COLOR_SPACE_BT709,
     DCP_COLOR_SPACE_BT601FR,
     DCP_COLOR_SPACE_BT709FR,
+    DCP_COLOR_SPACE_LRGB = DCP_COLOR_SPACE_RGB, /* Preserve backwards compatibility */
 } DcpColorSpace;
 
 /**
@@ -367,11 +374,11 @@ typedef enum {
  *
  * pixel_format          | color_space
  * ----------------------|---------------------------------------------
- * DCP_PIXEL_FORMAT_ARGB | DCP_COLOR_SPACE_LRGB
- * DCP_PIXEL_FORMAT_BGRA | DCP_COLOR_SPACE_LRGB
- * DCP_PIXEL_FORMAT_BGR  | DCP_COLOR_SPACE_LRGB
- * DCP_PIXEL_FORMAT_RGBA | DCP_COLOR_SPACE_LRGB
- * DCP_PIXEL_FORMAT_RGB  | DCP_COLOR_SPACE_LRGB
+ * DCP_PIXEL_FORMAT_ARGB | DCP_COLOR_SPACE_RGB
+ * DCP_PIXEL_FORMAT_BGRA | DCP_COLOR_SPACE_RGB
+ * DCP_PIXEL_FORMAT_BGR  | DCP_COLOR_SPACE_RGB
+ * DCP_PIXEL_FORMAT_RGBA | DCP_COLOR_SPACE_RGB
+ * DCP_PIXEL_FORMAT_RGB  | DCP_COLOR_SPACE_RGB
  * DCP_PIXEL_FORMAT_I444 | DCP_COLOR_SPACE_BT601(FR), DCP_COLOR_SPACE_BT709(FR)
  * DCP_PIXEL_FORMAT_I422 | DCP_COLOR_SPACE_BT601(FR), DCP_COLOR_SPACE_BT709(FR)
  * DCP_PIXEL_FORMAT_I420 | DCP_COLOR_SPACE_BT601(FR), DCP_COLOR_SPACE_BT709(FR)

--- a/src/color_space.rs
+++ b/src/color_space.rs
@@ -24,8 +24,13 @@
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub enum ColorSpace {
-    /// Gamma-corrected RGB
-    Lrgb,
+    /// Gamma-corrected R'G'B'.
+    /// The gamma is the one defined in ITU-R Recommendation BT.709-6 page 3, item 1.2
+    /// The relationship between gamma-corrected component (C') and its linear value (C)
+    /// is the following one:
+    /// C' = 4.5 * C                      if C < 0.018,
+    ///      1.099 * pow(C, 0.45) - 0.099 otherwise.
+    Rgb,
     /// YCbCr, ITU-R Recommendation BT.601 (standard video system)
     Bt601,
     /// YCbCr, ITU-R Recommendation BT.709 (CSC systems)
@@ -34,4 +39,11 @@ pub enum ColorSpace {
     Bt601FR,
     /// YCbCr, BT.709 (full range)
     Bt709FR,
+}
+
+impl ColorSpace {
+    #[deprecated(since = "0.5.0", note = "Lrgb is the same as Rgb. Use ColorSpace::Rgb")]
+    #[allow(non_upper_case_globals)]
+    /// Deprecated. Same as `ColorSpace::Rgb`
+    pub const Lrgb: ColorSpace = ColorSpace::Rgb;
 }

--- a/src/convert_image/avx2.rs
+++ b/src/convert_image/avx2.rs
@@ -17,6 +17,7 @@
 #![allow(clippy::wildcard_imports)]
 use crate::convert_image::common::*; // We are importing everything
 use crate::convert_image::x86;
+use crate::{rgb_to_yuv_converter, yuv_to_rgb_converter};
 
 use core::ptr::{read_unaligned as loadu, write_unaligned as storeu};
 
@@ -1433,18 +1434,20 @@ unsafe fn i444_to_rgb_avx2(
     }
 }
 
+// Internal module functions
 #[inline(never)]
-fn nv12_bgra_rgb(
+fn nv12_bgra(
     width: u32,
     height: u32,
     last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
     colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1534,16 +1537,18 @@ fn nv12_bgra_rgb(
 }
 
 #[inline(never)]
-fn i420_bgra_rgb(
+fn i420_bgra(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
     colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1637,16 +1642,18 @@ fn i420_bgra_rgb(
 }
 
 #[inline(never)]
-fn i444_bgra_rgb(
+fn i444_bgra(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
     colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1736,219 +1743,15 @@ fn i444_bgra_rgb(
 }
 
 #[inline(never)]
-fn rgb_i444(
-    width: u32,
-    height: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-    channels: PixelFormatChannels,
-    colorimetry: usize,
-    sampler: Sampler,
-) -> bool {
-    // Degenerate case, trivially accept
-    if width == 0 || height == 0 {
-        return true;
-    }
-
-    // Check there are sufficient strides and buffers
-    if src_strides.is_empty()
-        || src_buffers.is_empty()
-        || dst_strides.len() < 3
-        || dst_buffers.len() < 3
-    {
-        return false;
-    }
-
-    let w = width as usize;
-    let h = height as usize;
-    let depth = channels as usize;
-    let rgb_stride = depth * w;
-
-    // Compute actual strides
-    let src_stride = compute_stride(src_strides[0], rgb_stride);
-    let dst_strides = (
-        compute_stride(dst_strides[0], w),
-        compute_stride(dst_strides[1], w),
-        compute_stride(dst_strides[2], w),
-    );
-
-    // Ensure there is sufficient data in the buffers according
-    // to the image dimensions and computed strides
-    let src_buffer = &src_buffers[0];
-    let (y_plane, uv_plane) = dst_buffers.split_at_mut(1);
-    let (u_plane, v_plane) = uv_plane.split_at_mut(1);
-    let (y_plane, u_plane, v_plane) = (&mut *y_plane[0], &mut *u_plane[0], &mut *v_plane[0]);
-    if out_of_bounds(src_buffer.len(), src_stride, h - 1, rgb_stride)
-        || out_of_bounds(y_plane.len(), dst_strides.0, h - 1, w)
-        || out_of_bounds(u_plane.len(), dst_strides.1, h - 1, w)
-        || out_of_bounds(v_plane.len(), dst_strides.2, h - 1, w)
-    {
-        return false;
-    }
-
-    // Process vector part and scalar one
-    let vector_part = lower_multiple_of_pot(w, RGB_TO_YUV_WAVES);
-    let scalar_part = w - vector_part;
-    if vector_part > 0 {
-        unsafe {
-            rgb_to_i444_avx2(
-                vector_part,
-                h,
-                src_stride,
-                src_buffer,
-                dst_strides,
-                &mut (y_plane, u_plane, v_plane),
-                depth,
-                &FORWARD_WEIGHTS[colorimetry],
-                sampler,
-            );
-        }
-    }
-
-    if scalar_part > 0 {
-        let x = vector_part;
-        let sx = x * depth;
-
-        // The compiler is not smart here
-        // This condition should never happen
-        if sx >= src_buffer.len() || x >= y_plane.len() || x >= u_plane.len() || x >= v_plane.len()
-        {
-            return false;
-        }
-
-        x86::rgb_to_i444(
-            scalar_part,
-            h,
-            src_stride,
-            &src_buffer[sx..],
-            dst_strides,
-            &mut (&mut y_plane[x..], &mut u_plane[x..], &mut v_plane[x..]),
-            depth,
-            &x86::FORWARD_WEIGHTS[colorimetry],
-            sampler,
-        );
-    }
-
-    true
-}
-
-#[inline(never)]
-fn rgb_i420(
-    width: u32,
-    height: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-    channels: PixelFormatChannels,
-    colorimetry: usize,
-    sampler: Sampler,
-) -> bool {
-    // Degenerate case, trivially accept
-    if width == 0 || height == 0 {
-        return true;
-    }
-
-    // Check there are sufficient strides and buffers
-    if src_strides.is_empty()
-        || src_buffers.is_empty()
-        || dst_strides.len() < 3
-        || dst_buffers.len() < 3
-    {
-        return false;
-    }
-
-    let w = width as usize;
-    let h = height as usize;
-    let cw = w / 2;
-    let ch = h / 2;
-    let depth = channels as usize;
-    let rgb_stride = depth * w;
-
-    // Compute actual strides
-    let src_stride = compute_stride(src_strides[0], rgb_stride);
-    let dst_strides = (
-        compute_stride(dst_strides[0], w),
-        compute_stride(dst_strides[1], cw),
-        compute_stride(dst_strides[2], cw),
-    );
-
-    // Ensure there is sufficient data in the buffers according
-    // to the image dimensions and computed strides
-    let src_buffer = &src_buffers[0];
-    let (y_plane, uv_plane) = dst_buffers.split_at_mut(1);
-    let (u_plane, v_plane) = uv_plane.split_at_mut(1);
-    let (y_plane, u_plane, v_plane) = (&mut *y_plane[0], &mut *u_plane[0], &mut *v_plane[0]);
-    if out_of_bounds(src_buffer.len(), src_stride, h - 1, rgb_stride)
-        || out_of_bounds(y_plane.len(), dst_strides.0, h - 1, w)
-        || out_of_bounds(u_plane.len(), dst_strides.1, ch - 1, cw)
-        || out_of_bounds(v_plane.len(), dst_strides.2, ch - 1, cw)
-    {
-        return false;
-    }
-
-    // Process vector part and scalar one
-    let vector_part = lower_multiple_of_pot(w, RGB_TO_YUV_WAVES);
-    let scalar_part = w - vector_part;
-    if vector_part > 0 {
-        unsafe {
-            rgb_to_i420_avx2(
-                vector_part,
-                h,
-                src_stride,
-                src_buffer,
-                dst_strides,
-                &mut (y_plane, u_plane, v_plane),
-                depth,
-                &FORWARD_WEIGHTS[colorimetry],
-                sampler,
-            );
-        }
-    }
-
-    if scalar_part > 0 {
-        let x = vector_part;
-        let cx = x / 2;
-        let sx = x * depth;
-
-        // The compiler is not smart here
-        // This condition should never happen
-        if sx >= src_buffer.len()
-            || x >= y_plane.len()
-            || cx >= u_plane.len()
-            || cx >= v_plane.len()
-        {
-            return false;
-        }
-
-        x86::rgb_to_i420(
-            scalar_part,
-            h,
-            src_stride,
-            &src_buffer[sx..],
-            dst_strides,
-            &mut (&mut y_plane[x..], &mut u_plane[cx..], &mut v_plane[cx..]),
-            depth,
-            &x86::FORWARD_WEIGHTS[colorimetry],
-            sampler,
-        );
-    }
-
-    true
-}
-
-#[inline(never)]
 fn rgb_nv12(
     width: u32,
     height: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
     last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    channels: PixelFormatChannels,
     colorimetry: usize,
     sampler: Sampler,
 ) -> bool {
@@ -1969,7 +1772,10 @@ fn rgb_nv12(
     let w = width as usize;
     let h = height as usize;
     let ch = h / 2;
-    let depth = channels as usize;
+    let depth = match sampler {
+        Sampler::Bgr => 3_usize,
+        _ => 4_usize,
+    };
     let rgb_stride = depth * w;
 
     // Compute actual strides
@@ -2046,162 +1852,19 @@ fn rgb_nv12(
     true
 }
 
-pub fn argb_rgb_nv12_bt601(
+#[inline(never)]
+fn rgb_i420(
     width: u32,
     height: u32,
-    _last_src_plane: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
-    last_dst_plane: u32,
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
+    colorimetry: usize,
+    sampler: Sampler,
 ) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn argb_rgb_nv12_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_rgb_nv12_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgra_rgb_nv12_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_rgb_nv12_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn bgr_rgb_nv12_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn bgr_rgb_rgb_rgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    const DEPTH: usize = PixelFormatChannels::Three as usize;
-
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
         return true;
@@ -2210,113 +1873,247 @@ pub fn bgr_rgb_rgb_rgb(
     // Check there are sufficient strides and buffers
     if src_strides.is_empty()
         || src_buffers.is_empty()
-        || dst_strides.is_empty()
-        || dst_buffers.is_empty()
+        || dst_strides.len() < 3
+        || dst_buffers.len() < 3
     {
         return false;
     }
 
     let w = width as usize;
     let h = height as usize;
+    let cw = w / 2;
+    let ch = h / 2;
+    let depth = match sampler {
+        Sampler::Bgr => 3_usize,
+        _ => 4_usize,
+    };
+    let rgb_stride = depth * w;
 
     // Compute actual strides
-    let src_stride = compute_stride(src_strides[0], DEPTH * w);
-    let dst_stride = compute_stride(dst_strides[0], DEPTH * w);
+    let src_stride = compute_stride(src_strides[0], rgb_stride);
+    let dst_strides = (
+        compute_stride(dst_strides[0], w),
+        compute_stride(dst_strides[1], cw),
+        compute_stride(dst_strides[2], cw),
+    );
 
     // Ensure there is sufficient data in the buffers according
     // to the image dimensions and computed strides
-    let src_buffer = src_buffers[0];
-    let dst_buffer = &mut *dst_buffers[0];
-    if out_of_bounds(src_buffer.len(), src_stride, h - 1, w)
-        || out_of_bounds(dst_buffer.len(), dst_stride, h - 1, w)
+    let src_buffer = &src_buffers[0];
+    let (y_plane, uv_plane) = dst_buffers.split_at_mut(1);
+    let (u_plane, v_plane) = uv_plane.split_at_mut(1);
+    let (y_plane, u_plane, v_plane) = (&mut *y_plane[0], &mut *u_plane[0], &mut *v_plane[0]);
+    if out_of_bounds(src_buffer.len(), src_stride, h - 1, rgb_stride)
+        || out_of_bounds(y_plane.len(), dst_strides.0, h - 1, w)
+        || out_of_bounds(u_plane.len(), dst_strides.1, ch - 1, cw)
+        || out_of_bounds(v_plane.len(), dst_strides.2, ch - 1, cw)
     {
         return false;
     }
 
-    let vector_part = lower_multiple_of_pot(w, LANE_COUNT);
+    // Process vector part and scalar one
+    let vector_part = lower_multiple_of_pot(w, RGB_TO_YUV_WAVES);
     let scalar_part = w - vector_part;
     if vector_part > 0 {
         unsafe {
-            bgr_to_rgb_avx2(
+            rgb_to_i420_avx2(
                 vector_part,
                 h,
                 src_stride,
                 src_buffer,
-                dst_stride,
-                dst_buffer,
+                dst_strides,
+                &mut (y_plane, u_plane, v_plane),
+                depth,
+                &FORWARD_WEIGHTS[colorimetry],
+                sampler,
             );
         }
     }
 
     if scalar_part > 0 {
         let x = vector_part;
-        let sx = x * DEPTH;
-        let dx = x * DEPTH;
+        let cx = x / 2;
+        let sx = x * depth;
 
         // The compiler is not smart here
         // This condition should never happen
-        if sx >= src_buffer.len() || dx >= dst_buffer.len() {
+        if sx >= src_buffer.len()
+            || x >= y_plane.len()
+            || cx >= u_plane.len()
+            || cx >= v_plane.len()
+        {
             return false;
         }
 
-        x86::bgr_to_rgb(
+        x86::rgb_to_i420(
             scalar_part,
             h,
             src_stride,
             &src_buffer[sx..],
-            dst_stride,
-            &mut dst_buffer[dx..],
+            dst_strides,
+            &mut (&mut y_plane[x..], &mut u_plane[cx..], &mut v_plane[cx..]),
+            depth,
+            &x86::FORWARD_WEIGHTS[colorimetry],
+            sampler,
         );
     }
 
     true
 }
 
-pub fn nv12_bt601_bgra_rgb(
+#[inline(never)]
+fn rgb_i444(
     width: u32,
     height: u32,
-    last_src_plane: u32,
+    _last_src_plane: usize,
     src_strides: &[usize],
     src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
+    _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
+    colorimetry: usize,
+    sampler: Sampler,
 ) -> bool {
-    nv12_bgra_rgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601 as usize,
-    )
+    // Degenerate case, trivially accept
+    if width == 0 || height == 0 {
+        return true;
+    }
+
+    // Check there are sufficient strides and buffers
+    if src_strides.is_empty()
+        || src_buffers.is_empty()
+        || dst_strides.len() < 3
+        || dst_buffers.len() < 3
+    {
+        return false;
+    }
+
+    let w = width as usize;
+    let h = height as usize;
+    let depth = match sampler {
+        Sampler::Bgr => 3_usize,
+        _ => 4_usize,
+    };
+    let rgb_stride = depth * w;
+
+    // Compute actual strides
+    let src_stride = compute_stride(src_strides[0], rgb_stride);
+    let dst_strides = (
+        compute_stride(dst_strides[0], w),
+        compute_stride(dst_strides[1], w),
+        compute_stride(dst_strides[2], w),
+    );
+
+    // Ensure there is sufficient data in the buffers according
+    // to the image dimensions and computed strides
+    let src_buffer = &src_buffers[0];
+    let (y_plane, uv_plane) = dst_buffers.split_at_mut(1);
+    let (u_plane, v_plane) = uv_plane.split_at_mut(1);
+    let (y_plane, u_plane, v_plane) = (&mut *y_plane[0], &mut *u_plane[0], &mut *v_plane[0]);
+    if out_of_bounds(src_buffer.len(), src_stride, h - 1, rgb_stride)
+        || out_of_bounds(y_plane.len(), dst_strides.0, h - 1, w)
+        || out_of_bounds(u_plane.len(), dst_strides.1, h - 1, w)
+        || out_of_bounds(v_plane.len(), dst_strides.2, h - 1, w)
+    {
+        return false;
+    }
+
+    // Process vector part and scalar one
+    let vector_part = lower_multiple_of_pot(w, RGB_TO_YUV_WAVES);
+    let scalar_part = w - vector_part;
+    if vector_part > 0 {
+        unsafe {
+            rgb_to_i444_avx2(
+                vector_part,
+                h,
+                src_stride,
+                src_buffer,
+                dst_strides,
+                &mut (y_plane, u_plane, v_plane),
+                depth,
+                &FORWARD_WEIGHTS[colorimetry],
+                sampler,
+            );
+        }
+    }
+
+    if scalar_part > 0 {
+        let x = vector_part;
+        let sx = x * depth;
+
+        // The compiler is not smart here
+        // This condition should never happen
+        if sx >= src_buffer.len() || x >= y_plane.len() || x >= u_plane.len() || x >= v_plane.len()
+        {
+            return false;
+        }
+
+        x86::rgb_to_i444(
+            scalar_part,
+            h,
+            src_stride,
+            &src_buffer[sx..],
+            dst_strides,
+            &mut (&mut y_plane[x..], &mut u_plane[x..], &mut v_plane[x..]),
+            depth,
+            &x86::FORWARD_WEIGHTS[colorimetry],
+            sampler,
+        );
+    }
+
+    true
 }
 
-pub fn nv12_bt709_bgra_rgb(
-    width: u32,
-    height: u32,
-    last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    nv12_bgra_rgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709 as usize,
-    )
-}
+rgb_to_yuv_converter!(Argb, I420, Bt601);
+rgb_to_yuv_converter!(Argb, I420, Bt601FR);
+rgb_to_yuv_converter!(Argb, I420, Bt709);
+rgb_to_yuv_converter!(Argb, I420, Bt709FR);
+rgb_to_yuv_converter!(Argb, I444, Bt601);
+rgb_to_yuv_converter!(Argb, I444, Bt601FR);
+rgb_to_yuv_converter!(Argb, I444, Bt709);
+rgb_to_yuv_converter!(Argb, I444, Bt709FR);
+rgb_to_yuv_converter!(Argb, Nv12, Bt601);
+rgb_to_yuv_converter!(Argb, Nv12, Bt601FR);
+rgb_to_yuv_converter!(Argb, Nv12, Bt709);
+rgb_to_yuv_converter!(Argb, Nv12, Bt709FR);
+rgb_to_yuv_converter!(Bgr, I420, Bt601);
+rgb_to_yuv_converter!(Bgr, I420, Bt601FR);
+rgb_to_yuv_converter!(Bgr, I420, Bt709);
+rgb_to_yuv_converter!(Bgr, I420, Bt709FR);
+rgb_to_yuv_converter!(Bgr, I444, Bt601);
+rgb_to_yuv_converter!(Bgr, I444, Bt601FR);
+rgb_to_yuv_converter!(Bgr, I444, Bt709);
+rgb_to_yuv_converter!(Bgr, I444, Bt709FR);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt601);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt601FR);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt709);
+rgb_to_yuv_converter!(Bgr, Nv12, Bt709FR);
+rgb_to_yuv_converter!(Bgra, I420, Bt601);
+rgb_to_yuv_converter!(Bgra, I420, Bt601FR);
+rgb_to_yuv_converter!(Bgra, I420, Bt709);
+rgb_to_yuv_converter!(Bgra, I420, Bt709FR);
+rgb_to_yuv_converter!(Bgra, I444, Bt601);
+rgb_to_yuv_converter!(Bgra, I444, Bt601FR);
+rgb_to_yuv_converter!(Bgra, I444, Bt709);
+rgb_to_yuv_converter!(Bgra, I444, Bt709FR);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt601);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt601FR);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt709);
+rgb_to_yuv_converter!(Bgra, Nv12, Bt709FR);
+yuv_to_rgb_converter!(I420, Bt601);
+yuv_to_rgb_converter!(I420, Bt601FR);
+yuv_to_rgb_converter!(I420, Bt709);
+yuv_to_rgb_converter!(I420, Bt709FR);
+yuv_to_rgb_converter!(I444, Bt601);
+yuv_to_rgb_converter!(I444, Bt601FR);
+yuv_to_rgb_converter!(I444, Bt709);
+yuv_to_rgb_converter!(I444, Bt709FR);
+yuv_to_rgb_converter!(Nv12, Bt601);
+yuv_to_rgb_converter!(Nv12, Bt601FR);
+yuv_to_rgb_converter!(Nv12, Bt709);
+yuv_to_rgb_converter!(Nv12, Bt709FR);
 
-pub fn rgb_rgb_bgra_rgb(
+pub fn rgb_bgra(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2326,8 +2123,8 @@ pub fn rgb_rgb_bgra_rgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    const SRC_DEPTH: usize = PixelFormatChannels::Three as usize;
-    const DST_DEPTH: usize = PixelFormatChannels::Four as usize;
+    const SRC_DEPTH: usize = 3;
+    const DST_DEPTH: usize = 4;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -2400,7 +2197,7 @@ pub fn rgb_rgb_bgra_rgb(
     true
 }
 
-pub fn i420_bt601_bgra_rgb(
+pub fn bgra_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2410,368 +2207,8 @@ pub fn i420_bt601_bgra_rgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    i420_bgra_rgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601 as usize,
-    )
-}
-
-pub fn i420_bt709_bgra_rgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i420_bgra_rgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709 as usize,
-    )
-}
-
-pub fn i444_bt601_bgra_rgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_rgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601 as usize,
-    )
-}
-
-pub fn i444_bt709_bgra_rgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_rgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709 as usize,
-    )
-}
-
-pub fn argb_rgb_i420_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn argb_rgb_i420_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_rgb_i420_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgra_rgb_i420_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_rgb_i420_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn bgr_rgb_i420_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn argb_rgb_i444_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn argb_rgb_i444_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_rgb_i444_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgra_rgb_i444_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_rgb_i444_bt601(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn bgr_rgb_i444_bt709(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709 as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn bgra_rgb_rgb_rgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    const SRC_DEPTH: usize = PixelFormatChannels::Four as usize;
-    const DST_DEPTH: usize = PixelFormatChannels::Three as usize;
+    const SRC_DEPTH: usize = 4;
+    const DST_DEPTH: usize = 3;
 
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -2811,101 +2248,7 @@ pub fn bgra_rgb_rgb_rgb(
     true
 }
 
-pub fn argb_rgb_nv12_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_rgb_nv12_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_rgb_nv12_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn nv12_bt601fr_bgra_rgb(
-    width: u32,
-    height: u32,
-    last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    nv12_bgra_rgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601FR as usize,
-    )
-}
-
-pub fn i420_bt601fr_bgra_rgb(
+pub fn bgr_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2915,446 +2258,74 @@ pub fn i420_bt601fr_bgra_rgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    i420_bgra_rgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601FR as usize,
-    )
-}
+    const DEPTH: usize = 3;
 
-pub fn i444_bt601fr_bgra_rgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_rgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt601FR as usize,
-    )
-}
+    // Degenerate case, trivially accept
+    if width == 0 || height == 0 {
+        return true;
+    }
 
-pub fn argb_rgb_i420_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Argb,
-    )
-}
+    // Check there are sufficient strides and buffers
+    if src_strides.is_empty()
+        || src_buffers.is_empty()
+        || dst_strides.is_empty()
+        || dst_buffers.is_empty()
+    {
+        return false;
+    }
 
-pub fn bgra_rgb_i420_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgra,
-    )
-}
+    let w = width as usize;
+    let h = height as usize;
 
-pub fn bgr_rgb_i420_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgr,
-    )
-}
+    // Compute actual strides
+    let src_stride = compute_stride(src_strides[0], DEPTH * w);
+    let dst_stride = compute_stride(dst_strides[0], DEPTH * w);
 
-pub fn argb_rgb_i444_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Argb,
-    )
-}
+    // Ensure there is sufficient data in the buffers according
+    // to the image dimensions and computed strides
+    let src_buffer = src_buffers[0];
+    let dst_buffer = &mut *dst_buffers[0];
+    if out_of_bounds(src_buffer.len(), src_stride, h - 1, w)
+        || out_of_bounds(dst_buffer.len(), dst_stride, h - 1, w)
+    {
+        return false;
+    }
 
-pub fn bgra_rgb_i444_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgra,
-    )
-}
+    let vector_part = lower_multiple_of_pot(w, LANE_COUNT);
+    let scalar_part = w - vector_part;
+    if vector_part > 0 {
+        unsafe {
+            bgr_to_rgb_avx2(
+                vector_part,
+                h,
+                src_stride,
+                src_buffer,
+                dst_stride,
+                dst_buffer,
+            );
+        }
+    }
 
-pub fn bgr_rgb_i444_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgr,
-    )
-}
+    if scalar_part > 0 {
+        let x = vector_part;
+        let sx = x * DEPTH;
+        let dx = x * DEPTH;
 
-pub fn argb_rgb_nv12_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Argb,
-    )
-}
+        // The compiler is not smart here
+        // This condition should never happen
+        if sx >= src_buffer.len() || dx >= dst_buffer.len() {
+            return false;
+        }
 
-pub fn bgra_rgb_nv12_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgra,
-    )
-}
+        x86::bgr_to_rgb(
+            scalar_part,
+            h,
+            src_stride,
+            &src_buffer[sx..],
+            dst_stride,
+            &mut dst_buffer[dx..],
+        );
+    }
 
-pub fn bgr_rgb_nv12_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_nv12(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        last_dst_plane as usize,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn nv12_bt709fr_bgra_rgb(
-    width: u32,
-    height: u32,
-    last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    nv12_bgra_rgb(
-        width,
-        height,
-        last_src_plane as usize,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709FR as usize,
-    )
-}
-
-pub fn i420_bt709fr_bgra_rgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i420_bgra_rgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709FR as usize,
-    )
-}
-
-pub fn i444_bt709fr_bgra_rgb(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    i444_bgra_rgb(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        Colorimetry::Bt709FR as usize,
-    )
-}
-
-pub fn argb_rgb_i420_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_rgb_i420_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_rgb_i420_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn argb_rgb_i444_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_rgb_i444_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_rgb_i444_bt709fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    rgb_i444(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt709FR as usize,
-        Sampler::Bgr,
-    )
+    true
 }

--- a/src/convert_image/avx2.rs
+++ b/src/convert_image/avx2.rs
@@ -82,7 +82,7 @@ macro_rules! align_dqword_2x96 {
     };
 }
 
-const FORWARD_WEIGHTS: [[i32; 8]; Colorimetry::Length as usize] = [
+const FORWARD_WEIGHTS: [[i32; 7]; Colorimetry::Length as usize] = [
     [
         i32x2_to_i32(XG_601 - SHORT_HALF, XR_601),
         i32x2_to_i32(SHORT_HALF, XB_601),
@@ -91,7 +91,6 @@ const FORWARD_WEIGHTS: [[i32; 8]; Colorimetry::Length as usize] = [
         i32x2_to_i32(0, ZB_601),
         i32x2_to_i32(0, YB_601),
         Y_OFFSET,
-        0,
     ],
     [
         i32x2_to_i32(XG_709 - SHORT_HALF, XR_709),
@@ -101,7 +100,6 @@ const FORWARD_WEIGHTS: [[i32; 8]; Colorimetry::Length as usize] = [
         i32x2_to_i32(0, ZB_709),
         i32x2_to_i32(0, YB_709),
         Y_OFFSET,
-        0,
     ],
     [
         i32x2_to_i32(XG_601FR - SHORT_HALF, XR_601FR),
@@ -111,7 +109,6 @@ const FORWARD_WEIGHTS: [[i32; 8]; Colorimetry::Length as usize] = [
         i32x2_to_i32(0, ZB_601FR),
         i32x2_to_i32(0, YB_601FR - SHORT_HALF),
         FIX16_HALF,
-        1,
     ],
     [
         i32x2_to_i32(XG_709FR - SHORT_HALF, XR_709FR),
@@ -121,7 +118,6 @@ const FORWARD_WEIGHTS: [[i32; 8]; Colorimetry::Length as usize] = [
         i32x2_to_i32(0, ZB_709FR),
         i32x2_to_i32(0, YB_709FR - SHORT_HALF),
         FIX16_HALF,
-        1,
     ],
 ];
 
@@ -256,40 +252,36 @@ unsafe fn pack_i16x3_16x(image: *mut u8, red: __m256i, green: __m256i, blue: __m
 /// Convert 3 deinterleaved uchar samples into 2 deinterleaved
 /// short samples (8-wide)
 #[inline(always)]
-unsafe fn unpack_ui8x3_i16x2_8x(image: *const u8, sampler: Sampler) -> (__m256i, __m256i) {
-    let line = match sampler {
-        Sampler::BgrOverflow => {
-            let bgr: *const i64 = image.cast();
-            _mm256_set_epi64x(0, loadu(bgr.add(2)), loadu(bgr.add(1)), loadu(bgr))
-        }
-        _ => loadu(image.cast()),
+unsafe fn unpack_ui8x3_i16x2_8x<const SAMPLER: usize>(image: *const u8) -> (__m256i, __m256i) {
+    let line = if SAMPLER == Sampler::BgrOverflow as usize {
+        let bgr: *const i64 = image.cast();
+        _mm256_set_epi64x(0, loadu(bgr.add(2)), loadu(bgr.add(1)), loadu(bgr))
+    } else {
+        loadu(image.cast())
     };
 
-    let aligned_line = match sampler {
-        Sampler::Bgr | Sampler::BgrOverflow => {
-            let l = _mm256_permutevar8x32_epi32(line, align_dqword_2x96!());
-            _mm256_unpacklo_epi64(
-                _mm256_unpacklo_epi32(l, _mm256_srli_si256(l, 3)),
-                _mm256_unpacklo_epi32(_mm256_srli_si256(l, 6), _mm256_srli_si256(l, 9)),
-            )
-        }
-        _ => line,
+    let line = if SAMPLER == Sampler::Bgr as usize || SAMPLER == Sampler::BgrOverflow as usize {
+        let l = _mm256_permutevar8x32_epi32(line, align_dqword_2x96!());
+        _mm256_unpacklo_epi64(
+            _mm256_unpacklo_epi32(l, _mm256_srli_si256(l, 3)),
+            _mm256_unpacklo_epi32(_mm256_srli_si256(l, 6), _mm256_srli_si256(l, 9)),
+        )
+    } else {
+        line
     };
 
-    let (red, blue, green) = match sampler {
-        Sampler::Argb => (
-            _mm256_srli_epi32(_mm256_slli_epi32(aligned_line, 16), 24),
-            _mm256_srli_epi32(aligned_line, 24),
-            _mm256_srli_epi32(
-                _mm256_slli_epi32(_mm256_srli_epi32(aligned_line, 16), 24),
-                8,
-            ),
-        ),
-        _ => (
-            _mm256_srli_epi32(_mm256_slli_epi32(aligned_line, 8), 24),
-            _mm256_srli_epi32(_mm256_slli_epi32(aligned_line, 24), 24),
-            _mm256_srli_epi32(_mm256_slli_epi32(_mm256_srli_epi32(aligned_line, 8), 24), 8),
-        ),
+    let (red, blue, green) = if SAMPLER == Sampler::Argb as usize {
+        (
+            _mm256_srli_epi32(_mm256_slli_epi32(line, 16), 24),
+            _mm256_srli_epi32(line, 24),
+            _mm256_srli_epi32(_mm256_slli_epi32(_mm256_srli_epi32(line, 16), 24), 8),
+        )
+    } else {
+        (
+            _mm256_srli_epi32(_mm256_slli_epi32(line, 8), 24),
+            _mm256_srli_epi32(_mm256_slli_epi32(line, 24), 24),
+            _mm256_srli_epi32(_mm256_slli_epi32(_mm256_srli_epi32(line, 8), 24), 8),
+        )
     };
 
     (_mm256_or_si256(red, green), _mm256_or_si256(blue, green))
@@ -332,24 +324,22 @@ unsafe fn sum_i16x2_neighborhood_4x(xy0: __m256i, xy1: __m256i) -> __m256i {
 
 /// Convert linear rgb to yuv colorspace (8-wide)
 #[inline(always)]
-unsafe fn rgb_to_yuv_8x(
+unsafe fn rgb_to_yuv_8x<const SAMPLER: usize, const COLORIMETRY: usize>(
     rgb0: *const u8,
     rgb1: *const u8,
     y0: *mut u8,
     y1: *mut u8,
     uv: *mut u8,
-    sampler: Sampler,
     y_weigths: &[__m256i; 3],
     uv_weights: &[__m256i; 3],
-    full_range: bool,
 ) {
-    let (rg0, bg0) = unpack_ui8x3_i16x2_8x(rgb0, sampler);
+    let (rg0, bg0) = unpack_ui8x3_i16x2_8x::<SAMPLER>(rgb0);
     pack_i32_8x(
         y0,
         fix_to_i32_8x!(affine_transform(rg0, bg0, y_weigths), FIX16),
     );
 
-    let (rg1, bg1) = unpack_ui8x3_i16x2_8x(rgb1, sampler);
+    let (rg1, bg1) = unpack_ui8x3_i16x2_8x::<SAMPLER>(rgb1);
     pack_i32_8x(
         y1,
         fix_to_i32_8x!(affine_transform(rg1, bg1, y_weigths), FIX16),
@@ -358,7 +348,7 @@ unsafe fn rgb_to_yuv_8x(
     let srg = sum_i16x2_neighborhood_4x(rg0, rg1);
     let sbg = sum_i16x2_neighborhood_4x(bg0, bg1);
     let mut t = affine_transform(srg, sbg, uv_weights);
-    if full_range {
+    if is_full_range::<COLORIMETRY>() {
         t = _mm256_add_epi32(
             t,
             _mm256_slli_epi32(
@@ -375,25 +365,23 @@ unsafe fn rgb_to_yuv_8x(
 }
 
 #[inline(always)]
-unsafe fn rgb_to_i420_8x(
+unsafe fn rgb_to_i420_8x<const SAMPLER: usize, const COLORIMETRY: usize>(
     rgb0: *const u8,
     rgb1: *const u8,
     y0: *mut u8,
     y1: *mut u8,
     u: *mut u8,
     v: *mut u8,
-    sampler: Sampler,
     y_weigths: &[__m256i; 3],
     uv_weights: &[__m256i; 3],
-    full_range: bool,
 ) {
-    let (rg0, bg0) = unpack_ui8x3_i16x2_8x(rgb0, sampler);
+    let (rg0, bg0) = unpack_ui8x3_i16x2_8x::<SAMPLER>(rgb0);
     pack_i32_8x(
         y0,
         fix_to_i32_8x!(affine_transform(rg0, bg0, y_weigths), FIX16),
     );
 
-    let (rg1, bg1) = unpack_ui8x3_i16x2_8x(rgb1, sampler);
+    let (rg1, bg1) = unpack_ui8x3_i16x2_8x::<SAMPLER>(rgb1);
     pack_i32_8x(
         y1,
         fix_to_i32_8x!(affine_transform(rg1, bg1, y_weigths), FIX16),
@@ -402,7 +390,7 @@ unsafe fn rgb_to_i420_8x(
     let srg = sum_i16x2_neighborhood_4x(rg0, rg1);
     let sbg = sum_i16x2_neighborhood_4x(bg0, bg1);
     let mut t = affine_transform(srg, sbg, uv_weights);
-    if full_range {
+    if is_full_range::<COLORIMETRY>() {
         t = _mm256_add_epi32(
             t,
             _mm256_slli_epi32(
@@ -437,18 +425,16 @@ unsafe fn rgb_to_i420_8x(
 }
 
 #[inline(always)]
-unsafe fn rgb_to_i444_8x(
+unsafe fn rgb_to_i444_8x<const SAMPLER: usize, const COLORIMETRY: usize>(
     rgb: *const u8,
     y: *mut u8,
     u: *mut u8,
     v: *mut u8,
-    sampler: Sampler,
     y_weights: &[__m256i; 3],
     u_weights: &[__m256i; 3],
     v_weights: &[__m256i; 3],
-    full_range: bool,
 ) {
-    let (rg, bg) = unpack_ui8x3_i16x2_8x(rgb, sampler);
+    let (rg, bg) = unpack_ui8x3_i16x2_8x::<SAMPLER>(rgb);
     pack_i32_8x(
         y,
         fix_to_i32_8x!(affine_transform(rg, bg, y_weights), FIX16),
@@ -456,7 +442,7 @@ unsafe fn rgb_to_i444_8x(
 
     let mut tu = affine_transform(rg, bg, u_weights);
     let mut tv = affine_transform(rg, bg, v_weights);
-    if full_range {
+    if is_full_range::<COLORIMETRY>() {
         tu = _mm256_add_epi32(tu, _mm256_srli_epi32(_mm256_slli_epi32(bg, 16), 2));
         tv = _mm256_add_epi32(tv, _mm256_srli_epi32(_mm256_slli_epi32(rg, 16), 2));
     }
@@ -474,21 +460,19 @@ const fn shuffle(z: u32, y: u32, x: u32, w: u32) -> i32 {
 
 #[inline]
 #[target_feature(enable = "avx2")]
-unsafe fn rgb_to_yuv_avx2(
+unsafe fn rgb_to_nv12_avx2<const SAMPLER: usize, const DEPTH: usize, const COLORIMETRY: usize>(
     width: usize,
     height: usize,
     src_stride: usize,
     src_buffer: &[u8],
     dst_strides: (usize, usize),
     dst_buffers: &mut (&mut [u8], &mut [u8]),
-    depth: usize,
-    weights: &[i32; 8],
-    sampler: Sampler,
 ) {
     const DST_DEPTH: usize = RGB_TO_YUV_WAVES;
 
     let (y_stride, uv_stride) = dst_strides;
 
+    let weights = &FORWARD_WEIGHTS[COLORIMETRY];
     let y_weigths = [
         _mm256_set1_epi32(weights[0]),
         _mm256_set1_epi32(weights[1]),
@@ -504,16 +488,20 @@ unsafe fn rgb_to_yuv_avx2(
             weights[4], weights[5], weights[4], weights[5], weights[4], weights[5], weights[4],
             weights[5],
         ),
-        _mm256_set1_epi32(C_OFFSET - FIX18_HALF * weights[7]),
+        _mm256_set1_epi32(if is_full_range::<COLORIMETRY>() {
+            C_OFFSET - FIX18_HALF
+        } else {
+            C_OFFSET
+        }),
     ];
 
     let src_group = src_buffer.as_ptr();
     let y_group = dst_buffers.0.as_mut_ptr();
     let uv_group = dst_buffers.1.as_mut_ptr();
 
-    let src_depth = depth * RGB_TO_YUV_WAVES;
+    let src_depth = DEPTH * RGB_TO_YUV_WAVES;
     let read_bytes_per_line = ((width - 1) / RGB_TO_YUV_WAVES) * src_depth + LANE_COUNT;
-    let y_start = if (depth == 4) || (read_bytes_per_line <= src_stride) {
+    let y_start = if (DEPTH == 4) || (read_bytes_per_line <= src_stride) {
         height
     } else {
         height - 2
@@ -524,16 +512,14 @@ unsafe fn rgb_to_yuv_avx2(
 
     for y in 0..wg_height {
         for x in 0..wg_width {
-            rgb_to_yuv_8x(
+            rgb_to_yuv_8x::<SAMPLER, COLORIMETRY>(
                 src_group.add(wg_index(x, 2 * y, src_depth, src_stride)),
                 src_group.add(wg_index(x, 2 * y + 1, src_depth, src_stride)),
                 y_group.add(wg_index(x, 2 * y, DST_DEPTH, y_stride)),
                 y_group.add(wg_index(x, 2 * y + 1, DST_DEPTH, y_stride)),
                 uv_group.add(wg_index(x, y, DST_DEPTH, uv_stride)),
-                sampler,
                 &y_weigths,
                 &uv_weights,
-                weights[7] == 1,
             );
         }
     }
@@ -542,49 +528,43 @@ unsafe fn rgb_to_yuv_avx2(
     if y_start != height {
         let rem = (width - RGB_TO_YUV_WAVES) / RGB_TO_YUV_WAVES;
         for x in 0..rem {
-            rgb_to_yuv_8x(
+            rgb_to_yuv_8x::<SAMPLER, COLORIMETRY>(
                 src_group.add(wg_index(x, y_start, src_depth, src_stride)),
                 src_group.add(wg_index(x, y_start + 1, src_depth, src_stride)),
                 y_group.add(wg_index(x, y_start, DST_DEPTH, y_stride)),
                 y_group.add(wg_index(x, y_start + 1, DST_DEPTH, y_stride)),
                 uv_group.add(wg_index(x, wg_height, DST_DEPTH, uv_stride)),
-                sampler,
                 &y_weigths,
                 &uv_weights,
-                weights[7] == 1,
             );
         }
 
         // Handle leftover pixels
-        rgb_to_yuv_8x(
+        rgb_to_yuv_8x::<{ Sampler::BgrOverflow as usize }, COLORIMETRY>(
             src_group.add(wg_index(rem, y_start, src_depth, src_stride)),
             src_group.add(wg_index(rem, y_start + 1, src_depth, src_stride)),
             y_group.add(wg_index(rem, y_start, DST_DEPTH, y_stride)),
             y_group.add(wg_index(rem, y_start + 1, DST_DEPTH, y_stride)),
             uv_group.add(wg_index(rem, wg_height, DST_DEPTH, uv_stride)),
-            Sampler::BgrOverflow,
             &y_weigths,
             &uv_weights,
-            weights[7] == 1,
         );
     }
 }
 
 #[inline]
 #[target_feature(enable = "avx2")]
-unsafe fn rgb_to_i420_avx2(
+unsafe fn rgb_to_i420_avx2<const SAMPLER: usize, const DEPTH: usize, const COLORIMETRY: usize>(
     width: usize,
     height: usize,
     src_stride: usize,
     src_buffer: &[u8],
     dst_strides: (usize, usize, usize),
     dst_buffers: &mut (&mut [u8], &mut [u8], &mut [u8]),
-    depth: usize,
-    weights: &[i32; 8],
-    sampler: Sampler,
 ) {
     let (y_stride, u_stride, v_stride) = dst_strides;
 
+    let weights = &FORWARD_WEIGHTS[COLORIMETRY];
     let y_weigths = [
         _mm256_set1_epi32(weights[0]),
         _mm256_set1_epi32(weights[1]),
@@ -600,7 +580,11 @@ unsafe fn rgb_to_i420_avx2(
             weights[4], weights[5], weights[4], weights[5], weights[4], weights[5], weights[4],
             weights[5],
         ),
-        _mm256_set1_epi32(C_OFFSET - FIX18_HALF * weights[7]),
+        _mm256_set1_epi32(if is_full_range::<COLORIMETRY>() {
+            C_OFFSET - FIX18_HALF
+        } else {
+            C_OFFSET
+        }),
     ];
 
     let src_group = src_buffer.as_ptr();
@@ -608,9 +592,9 @@ unsafe fn rgb_to_i420_avx2(
     let u_group = dst_buffers.1.as_mut_ptr();
     let v_group = dst_buffers.2.as_mut_ptr();
 
-    let src_depth = depth * RGB_TO_YUV_WAVES;
+    let src_depth = DEPTH * RGB_TO_YUV_WAVES;
     let read_bytes_per_line = ((width - 1) / RGB_TO_YUV_WAVES) * src_depth + LANE_COUNT;
-    let y_start = if (depth == 4) || (read_bytes_per_line <= src_stride) {
+    let y_start = if (DEPTH == 4) || (read_bytes_per_line <= src_stride) {
         height
     } else {
         height - 2
@@ -621,17 +605,15 @@ unsafe fn rgb_to_i420_avx2(
 
     for y in 0..wg_height {
         for x in 0..wg_width {
-            rgb_to_i420_8x(
+            rgb_to_i420_8x::<SAMPLER, COLORIMETRY>(
                 src_group.add(wg_index(x, 2 * y, src_depth, src_stride)),
                 src_group.add(wg_index(x, 2 * y + 1, src_depth, src_stride)),
                 y_group.add(wg_index(x, 2 * y, RGB_TO_YUV_WAVES, y_stride)),
                 y_group.add(wg_index(x, 2 * y + 1, RGB_TO_YUV_WAVES, y_stride)),
                 u_group.add(wg_index(x, y, RGB_TO_YUV_WAVES / 2, u_stride)),
                 v_group.add(wg_index(x, y, RGB_TO_YUV_WAVES / 2, v_stride)),
-                sampler,
                 &y_weigths,
                 &uv_weights,
-                weights[7] == 1,
             );
         }
     }
@@ -640,33 +622,453 @@ unsafe fn rgb_to_i420_avx2(
     if y_start != height {
         let rem = (width - RGB_TO_YUV_WAVES) / RGB_TO_YUV_WAVES;
         for x in 0..rem {
-            rgb_to_i420_8x(
+            rgb_to_i420_8x::<SAMPLER, COLORIMETRY>(
                 src_group.add(wg_index(x, y_start, src_depth, src_stride)),
                 src_group.add(wg_index(x, y_start + 1, src_depth, src_stride)),
                 y_group.add(wg_index(x, y_start, RGB_TO_YUV_WAVES, y_stride)),
                 y_group.add(wg_index(x, y_start + 1, RGB_TO_YUV_WAVES, y_stride)),
                 u_group.add(wg_index(x, wg_height, RGB_TO_YUV_WAVES / 2, u_stride)),
                 v_group.add(wg_index(x, wg_height, RGB_TO_YUV_WAVES / 2, v_stride)),
-                sampler,
                 &y_weigths,
                 &uv_weights,
-                weights[7] == 1,
             );
         }
 
         // Handle leftover pixels
-        rgb_to_i420_8x(
+        rgb_to_i420_8x::<{ Sampler::BgrOverflow as usize }, COLORIMETRY>(
             src_group.add(wg_index(rem, y_start, src_depth, src_stride)),
             src_group.add(wg_index(rem, y_start + 1, src_depth, src_stride)),
             y_group.add(wg_index(rem, y_start, RGB_TO_YUV_WAVES, y_stride)),
             y_group.add(wg_index(rem, y_start + 1, RGB_TO_YUV_WAVES, y_stride)),
             u_group.add(wg_index(rem, wg_height, RGB_TO_YUV_WAVES / 2, u_stride)),
             v_group.add(wg_index(rem, wg_height, RGB_TO_YUV_WAVES / 2, v_stride)),
-            Sampler::BgrOverflow,
             &y_weigths,
             &uv_weights,
-            weights[7] == 1,
         );
+    }
+}
+
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn rgb_to_i444_avx2<const SAMPLER: usize, const DEPTH: usize, const COLORIMETRY: usize>(
+    width: usize,
+    height: usize,
+    src_stride: usize,
+    src_buffer: &[u8],
+    dst_strides: (usize, usize, usize),
+    dst_buffers: &mut (&mut [u8], &mut [u8], &mut [u8]),
+) {
+    let (y_stride, u_stride, v_stride) = dst_strides;
+
+    let weights = &FORWARD_WEIGHTS[COLORIMETRY];
+    let y_weights = [
+        _mm256_set1_epi32(weights[0]),
+        _mm256_set1_epi32(weights[1]),
+        _mm256_set1_epi32(weights[6]),
+    ];
+
+    let u_weights = [
+        _mm256_set1_epi32(weights[3]),
+        _mm256_set1_epi32(weights[5]),
+        _mm256_set1_epi32(if is_full_range::<COLORIMETRY>() {
+            C_OFFSET16 - FIX16_HALF
+        } else {
+            C_OFFSET16
+        }),
+    ];
+
+    let v_weights = [
+        _mm256_set1_epi32(weights[2]),
+        _mm256_set1_epi32(weights[4]),
+        _mm256_set1_epi32(if is_full_range::<COLORIMETRY>() {
+            C_OFFSET16 - FIX16_HALF
+        } else {
+            C_OFFSET16
+        }),
+    ];
+
+    let src_group = src_buffer.as_ptr();
+    let y_group = dst_buffers.0.as_mut_ptr();
+    let u_group = dst_buffers.1.as_mut_ptr();
+    let v_group = dst_buffers.2.as_mut_ptr();
+
+    let rgb_depth = DEPTH * RGB_TO_YUV_WAVES;
+    let read_bytes_per_line = ((width - 1) / RGB_TO_YUV_WAVES) * rgb_depth + LANE_COUNT;
+    let y_start = if (DEPTH == 4) || (read_bytes_per_line <= src_stride) {
+        height
+    } else {
+        height - 1
+    };
+
+    let wg_width = width / RGB_TO_YUV_WAVES;
+    let wg_height = y_start;
+
+    for y in 0..wg_height {
+        for x in 0..wg_width {
+            rgb_to_i444_8x::<SAMPLER, COLORIMETRY>(
+                src_group.add(wg_index(x, y, rgb_depth, src_stride)),
+                y_group.add(wg_index(x, y, RGB_TO_YUV_WAVES, y_stride)),
+                u_group.add(wg_index(x, y, RGB_TO_YUV_WAVES, u_stride)),
+                v_group.add(wg_index(x, y, RGB_TO_YUV_WAVES, v_stride)),
+                &y_weights,
+                &u_weights,
+                &v_weights,
+            );
+        }
+    }
+
+    // Handle leftover line
+    if y_start != height {
+        let rem = (width - RGB_TO_YUV_WAVES) / RGB_TO_YUV_WAVES;
+        for x in 0..rem {
+            rgb_to_i444_8x::<SAMPLER, COLORIMETRY>(
+                src_group.add(wg_index(x, y_start, rgb_depth, src_stride)),
+                y_group.add(wg_index(x, y_start, RGB_TO_YUV_WAVES, y_stride)),
+                u_group.add(wg_index(x, y_start, RGB_TO_YUV_WAVES, u_stride)),
+                v_group.add(wg_index(x, y_start, RGB_TO_YUV_WAVES, v_stride)),
+                &y_weights,
+                &u_weights,
+                &v_weights,
+            );
+        }
+
+        // Handle leftover pixels
+        rgb_to_i444_8x::<{ Sampler::BgrOverflow as usize }, COLORIMETRY>(
+            src_group.add(wg_index(rem, y_start, rgb_depth, src_stride)),
+            y_group.add(wg_index(rem, y_start, RGB_TO_YUV_WAVES, y_stride)),
+            u_group.add(wg_index(rem, y_start, RGB_TO_YUV_WAVES, u_stride)),
+            v_group.add(wg_index(rem, y_start, RGB_TO_YUV_WAVES, v_stride)),
+            &y_weights,
+            &u_weights,
+            &v_weights,
+        );
+    }
+}
+
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn nv12_to_rgb_avx2<const COLORIMETRY: usize>(
+    width: usize,
+    height: usize,
+    src_strides: (usize, usize),
+    src_buffers: (&[u8], &[u8]),
+    dst_stride: usize,
+    dst_buffer: &mut [u8],
+) {
+    const SRC_DEPTH: usize = YUV_TO_RGB_WAVES;
+    const DST_DEPTH: usize = 2 * YUV_TO_RGB_WAVES;
+
+    let (y_stride, uv_stride) = src_strides;
+
+    let weights = &BACKWARD_WEIGHTS[COLORIMETRY];
+    let xxym = _mm256_set1_epi16(weights[0]);
+    let rcrm = _mm256_set1_epi16(weights[1]);
+    let gcrm = _mm256_set1_epi16(weights[2]);
+    let gcbm = _mm256_set1_epi16(weights[3]);
+    let bcbm = _mm256_set1_epi16(weights[4]);
+    let rn = _mm256_set1_epi16(weights[5]);
+    let gp = _mm256_set1_epi16(weights[6]);
+    let bn = _mm256_set1_epi16(weights[7]);
+
+    let y_group = src_buffers.0.as_ptr();
+    let uv_group = src_buffers.1.as_ptr();
+    let dst_group = dst_buffer.as_mut_ptr();
+
+    let wg_width = width / YUV_TO_RGB_WAVES;
+    let wg_height = height / 2;
+
+    for y in 0..wg_height {
+        for x in 0..wg_width {
+            let (cb, cr) =
+                unpack_ui8x2_i16be_16x(uv_group.add(wg_index(x, y, SRC_DEPTH, uv_stride)));
+
+            let sb = _mm256_sub_epi16(_mm256_mulhi_epu16(cb, bcbm), bn);
+            let sr = _mm256_sub_epi16(_mm256_mulhi_epu16(cr, rcrm), rn);
+            let sg = _mm256_sub_epi16(
+                gp,
+                _mm256_add_epi16(_mm256_mulhi_epu16(cb, gcbm), _mm256_mulhi_epu16(cr, gcrm)),
+            );
+
+            let (sb_lo, sb_hi) = i16_to_i16x2_16x(sb);
+            let (sr_lo, sr_hi) = i16_to_i16x2_16x(sr);
+            let (sg_lo, sg_hi) = i16_to_i16x2_16x(sg);
+
+            let y0 = loadu(y_group.add(wg_index(x, 2 * y, SRC_DEPTH, y_stride)).cast());
+
+            let y00 = _mm256_mulhi_epu16(
+                _mm256_permute2x128_si256(
+                    _mm256_unpacklo_epi8(zero!(), y0),
+                    _mm256_unpackhi_epi8(zero!(), y0),
+                    PACK_LO_DQWORD_2X256,
+                ),
+                xxym,
+            );
+            pack_i16x3_16x(
+                dst_group.add(wg_index(2 * x, 2 * y, DST_DEPTH, dst_stride)),
+                fix_to_i16_16x!(_mm256_add_epi16(sr_lo, y00), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sg_lo, y00), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sb_lo, y00), FIX6),
+            );
+
+            let y10 = _mm256_mulhi_epu16(
+                _mm256_permute2x128_si256(
+                    _mm256_unpacklo_epi8(zero!(), y0),
+                    _mm256_unpackhi_epi8(zero!(), y0),
+                    PACK_HI_DQWORD_2X256,
+                ),
+                xxym,
+            );
+            pack_i16x3_16x(
+                dst_group.add(wg_index(2 * x + 1, 2 * y, DST_DEPTH, dst_stride)),
+                fix_to_i16_16x!(_mm256_add_epi16(sr_hi, y10), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sg_hi, y10), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sb_hi, y10), FIX6),
+            );
+
+            let y1 = loadu(
+                y_group
+                    .add(wg_index(x, 2 * y + 1, SRC_DEPTH, y_stride))
+                    .cast(),
+            );
+
+            let y01 = _mm256_mulhi_epu16(
+                _mm256_permute2x128_si256(
+                    _mm256_unpacklo_epi8(zero!(), y1),
+                    _mm256_unpackhi_epi8(zero!(), y1),
+                    PACK_LO_DQWORD_2X256,
+                ),
+                xxym,
+            );
+            pack_i16x3_16x(
+                dst_group.add(wg_index(2 * x, 2 * y + 1, DST_DEPTH, dst_stride)),
+                fix_to_i16_16x!(_mm256_add_epi16(sr_lo, y01), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sg_lo, y01), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sb_lo, y01), FIX6),
+            );
+
+            let y11 = _mm256_mulhi_epu16(
+                _mm256_permute2x128_si256(
+                    _mm256_unpacklo_epi8(zero!(), y1),
+                    _mm256_unpackhi_epi8(zero!(), y1),
+                    PACK_HI_DQWORD_2X256,
+                ),
+                xxym,
+            );
+            pack_i16x3_16x(
+                dst_group.add(wg_index(2 * x + 1, 2 * y + 1, DST_DEPTH, dst_stride)),
+                fix_to_i16_16x!(_mm256_add_epi16(sr_hi, y11), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sg_hi, y11), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sb_hi, y11), FIX6),
+            );
+        }
+    }
+}
+
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn i420_to_rgb_avx2<const COLORIMETRY: usize>(
+    width: usize,
+    height: usize,
+    src_strides: (usize, usize, usize),
+    src_buffers: (&[u8], &[u8], &[u8]),
+    dst_stride: usize,
+    dst_buffer: &mut [u8],
+) {
+    const SRC_DEPTH: usize = YUV_TO_RGB_WAVES;
+    const DST_DEPTH: usize = 2 * YUV_TO_RGB_WAVES;
+
+    let (y_stride, u_stride, v_stride) = src_strides;
+
+    let weights = &BACKWARD_WEIGHTS[COLORIMETRY];
+    let xxym = _mm256_set1_epi16(weights[0]);
+    let rcrm = _mm256_set1_epi16(weights[1]);
+    let gcrm = _mm256_set1_epi16(weights[2]);
+    let gcbm = _mm256_set1_epi16(weights[3]);
+    let bcbm = _mm256_set1_epi16(weights[4]);
+    let rn = _mm256_set1_epi16(weights[5]);
+    let gp = _mm256_set1_epi16(weights[6]);
+    let bn = _mm256_set1_epi16(weights[7]);
+
+    let y_group = src_buffers.0.as_ptr();
+    let u_group = src_buffers.1.as_ptr();
+    let v_group = src_buffers.2.as_ptr();
+    let dst_group = dst_buffer.as_mut_ptr();
+
+    let wg_width = width / YUV_TO_RGB_WAVES;
+    let wg_height = height / 2;
+
+    for y in 0..wg_height {
+        for x in 0..wg_width {
+            let cb = unpack_ui8_i16be_16x(u_group.add(wg_index(x, y, SRC_DEPTH / 2, u_stride)));
+            let cr = unpack_ui8_i16be_16x(v_group.add(wg_index(x, y, SRC_DEPTH / 2, v_stride)));
+
+            let sb = _mm256_sub_epi16(_mm256_mulhi_epu16(cb, bcbm), bn);
+            let sr = _mm256_sub_epi16(_mm256_mulhi_epu16(cr, rcrm), rn);
+            let sg = _mm256_sub_epi16(
+                gp,
+                _mm256_add_epi16(_mm256_mulhi_epu16(cb, gcbm), _mm256_mulhi_epu16(cr, gcrm)),
+            );
+
+            let (sb_lo, sb_hi) = i16_to_i16x2_16x(sb);
+            let (sr_lo, sr_hi) = i16_to_i16x2_16x(sr);
+            let (sg_lo, sg_hi) = i16_to_i16x2_16x(sg);
+
+            let y0 = loadu(y_group.add(wg_index(x, 2 * y, SRC_DEPTH, y_stride)).cast());
+
+            let y00 = _mm256_mulhi_epu16(
+                _mm256_permute2x128_si256(
+                    _mm256_unpacklo_epi8(zero!(), y0),
+                    _mm256_unpackhi_epi8(zero!(), y0),
+                    PACK_LO_DQWORD_2X256,
+                ),
+                xxym,
+            );
+            pack_i16x3_16x(
+                dst_group.add(wg_index(2 * x, 2 * y, DST_DEPTH, dst_stride)),
+                fix_to_i16_16x!(_mm256_add_epi16(sr_lo, y00), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sg_lo, y00), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sb_lo, y00), FIX6),
+            );
+
+            let y10 = _mm256_mulhi_epu16(
+                _mm256_permute2x128_si256(
+                    _mm256_unpacklo_epi8(zero!(), y0),
+                    _mm256_unpackhi_epi8(zero!(), y0),
+                    PACK_HI_DQWORD_2X256,
+                ),
+                xxym,
+            );
+            pack_i16x3_16x(
+                dst_group.add(wg_index(2 * x + 1, 2 * y, DST_DEPTH, dst_stride)),
+                fix_to_i16_16x!(_mm256_add_epi16(sr_hi, y10), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sg_hi, y10), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sb_hi, y10), FIX6),
+            );
+
+            let y1 = loadu(
+                y_group
+                    .add(wg_index(x, 2 * y + 1, SRC_DEPTH, y_stride))
+                    .cast(),
+            );
+
+            let y01 = _mm256_mulhi_epu16(
+                _mm256_permute2x128_si256(
+                    _mm256_unpacklo_epi8(zero!(), y1),
+                    _mm256_unpackhi_epi8(zero!(), y1),
+                    PACK_LO_DQWORD_2X256,
+                ),
+                xxym,
+            );
+            pack_i16x3_16x(
+                dst_group.add(wg_index(2 * x, 2 * y + 1, DST_DEPTH, dst_stride)),
+                fix_to_i16_16x!(_mm256_add_epi16(sr_lo, y01), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sg_lo, y01), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sb_lo, y01), FIX6),
+            );
+
+            let y11 = _mm256_mulhi_epu16(
+                _mm256_permute2x128_si256(
+                    _mm256_unpacklo_epi8(zero!(), y1),
+                    _mm256_unpackhi_epi8(zero!(), y1),
+                    PACK_HI_DQWORD_2X256,
+                ),
+                xxym,
+            );
+            pack_i16x3_16x(
+                dst_group.add(wg_index(2 * x + 1, 2 * y + 1, DST_DEPTH, dst_stride)),
+                fix_to_i16_16x!(_mm256_add_epi16(sr_hi, y11), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sg_hi, y11), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sb_hi, y11), FIX6),
+            );
+        }
+    }
+}
+
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn i444_to_rgb_avx2<const COLORIMETRY: usize>(
+    width: usize,
+    height: usize,
+    src_strides: (usize, usize, usize),
+    src_buffers: (&[u8], &[u8], &[u8]),
+    dst_stride: usize,
+    dst_buffer: &mut [u8],
+) {
+    const SRC_DEPTH: usize = YUV_TO_RGB_WAVES / 2;
+    const DST_DEPTH: usize = 2 * YUV_TO_RGB_WAVES;
+
+    let (y_stride, u_stride, v_stride) = src_strides;
+
+    let weights = &BACKWARD_WEIGHTS[COLORIMETRY];
+    let xxym = _mm256_set1_epi16(weights[0]);
+    let rcrm = _mm256_set1_epi16(weights[1]);
+    let gcrm = _mm256_set1_epi16(weights[2]);
+    let gcbm = _mm256_set1_epi16(weights[3]);
+    let bcbm = _mm256_set1_epi16(weights[4]);
+    let rn = _mm256_set1_epi16(weights[5]);
+    let gp = _mm256_set1_epi16(weights[6]);
+    let bn = _mm256_set1_epi16(weights[7]);
+    let zero_128 = _mm_setzero_si128();
+
+    let y_group = src_buffers.0.as_ptr();
+    let u_group = src_buffers.1.as_ptr();
+    let v_group = src_buffers.2.as_ptr();
+    let dst_group = dst_buffer.as_mut_ptr();
+
+    let wg_width = width / SRC_DEPTH;
+
+    for y in 0..height {
+        for x in 0..wg_width {
+            let cb = _mm256_set_m128i(
+                zero_128,
+                loadu(u_group.add(wg_index(x, y, SRC_DEPTH, u_stride)).cast()),
+            );
+            let cr = _mm256_set_m128i(
+                zero_128,
+                loadu(v_group.add(wg_index(x, y, SRC_DEPTH, v_stride)).cast()),
+            );
+            let y0 = _mm256_set_m128i(
+                zero_128,
+                loadu(y_group.add(wg_index(x, y, SRC_DEPTH, y_stride)).cast()),
+            );
+
+            let cb_lo = _mm256_permute2x128_si256(
+                _mm256_unpacklo_epi8(zero!(), cb),
+                _mm256_unpackhi_epi8(zero!(), cb),
+                PACK_LO_DQWORD_2X256,
+            );
+
+            let cr_lo = _mm256_permute2x128_si256(
+                _mm256_unpacklo_epi8(zero!(), cr),
+                _mm256_unpackhi_epi8(zero!(), cr),
+                PACK_LO_DQWORD_2X256,
+            );
+
+            let sb_lo = _mm256_sub_epi16(_mm256_mulhi_epu16(cb_lo, bcbm), bn);
+            let sr_lo = _mm256_sub_epi16(_mm256_mulhi_epu16(cr_lo, rcrm), rn);
+            let sg_lo = _mm256_sub_epi16(
+                gp,
+                _mm256_add_epi16(
+                    _mm256_mulhi_epu16(cb_lo, gcbm),
+                    _mm256_mulhi_epu16(cr_lo, gcrm),
+                ),
+            );
+
+            let y_lo = _mm256_mulhi_epu16(
+                _mm256_permute2x128_si256(
+                    _mm256_unpacklo_epi8(zero!(), y0),
+                    _mm256_unpackhi_epi8(zero!(), y0),
+                    PACK_LO_DQWORD_2X256,
+                ),
+                xxym,
+            );
+            pack_i16x3_16x(
+                dst_group.add(wg_index(x, y, DST_DEPTH, dst_stride)),
+                fix_to_i16_16x!(_mm256_add_epi16(sr_lo, y_lo), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sg_lo, y_lo), FIX6),
+                fix_to_i16_16x!(_mm256_add_epi16(sb_lo, y_lo), FIX6),
+            );
+        }
     }
 }
 
@@ -1010,433 +1412,9 @@ unsafe fn rgb_to_bgra_avx2(
     }
 }
 
-#[inline]
-#[target_feature(enable = "avx2")]
-unsafe fn rgb_to_i444_avx2(
-    width: usize,
-    height: usize,
-    src_stride: usize,
-    src_buffer: &[u8],
-    dst_strides: (usize, usize, usize),
-    dst_buffers: &mut (&mut [u8], &mut [u8], &mut [u8]),
-    depth: usize,
-    weights: &[i32; 8],
-    sampler: Sampler,
-) {
-    let (y_stride, u_stride, v_stride) = dst_strides;
-
-    let y_weights = [
-        _mm256_set1_epi32(weights[0]),
-        _mm256_set1_epi32(weights[1]),
-        _mm256_set1_epi32(weights[6]),
-    ];
-
-    let u_weights = [
-        _mm256_set1_epi32(weights[3]),
-        _mm256_set1_epi32(weights[5]),
-        _mm256_set1_epi32(C_OFFSET16 - FIX16_HALF * weights[7]),
-    ];
-
-    let v_weights = [
-        _mm256_set1_epi32(weights[2]),
-        _mm256_set1_epi32(weights[4]),
-        _mm256_set1_epi32(C_OFFSET16 - FIX16_HALF * weights[7]),
-    ];
-
-    let src_group = src_buffer.as_ptr();
-    let y_group = dst_buffers.0.as_mut_ptr();
-    let u_group = dst_buffers.1.as_mut_ptr();
-    let v_group = dst_buffers.2.as_mut_ptr();
-
-    let rgb_depth = depth * RGB_TO_YUV_WAVES;
-    let read_bytes_per_line = ((width - 1) / RGB_TO_YUV_WAVES) * rgb_depth + LANE_COUNT;
-    let y_start = if (depth == 4) || (read_bytes_per_line <= src_stride) {
-        height
-    } else {
-        height - 1
-    };
-
-    let wg_width = width / RGB_TO_YUV_WAVES;
-    let wg_height = y_start;
-
-    for y in 0..wg_height {
-        for x in 0..wg_width {
-            rgb_to_i444_8x(
-                src_group.add(wg_index(x, y, rgb_depth, src_stride)),
-                y_group.add(wg_index(x, y, RGB_TO_YUV_WAVES, y_stride)),
-                u_group.add(wg_index(x, y, RGB_TO_YUV_WAVES, u_stride)),
-                v_group.add(wg_index(x, y, RGB_TO_YUV_WAVES, v_stride)),
-                sampler,
-                &y_weights,
-                &u_weights,
-                &v_weights,
-                weights[7] == 1,
-            );
-        }
-    }
-
-    // Handle leftover line
-    if y_start != height {
-        let rem = (width - RGB_TO_YUV_WAVES) / RGB_TO_YUV_WAVES;
-        for x in 0..rem {
-            rgb_to_i444_8x(
-                src_group.add(wg_index(x, y_start, rgb_depth, src_stride)),
-                y_group.add(wg_index(x, y_start, RGB_TO_YUV_WAVES, y_stride)),
-                u_group.add(wg_index(x, y_start, RGB_TO_YUV_WAVES, u_stride)),
-                v_group.add(wg_index(x, y_start, RGB_TO_YUV_WAVES, v_stride)),
-                sampler,
-                &y_weights,
-                &u_weights,
-                &v_weights,
-                weights[7] == 1,
-            );
-        }
-
-        // Handle leftover pixels
-        rgb_to_i444_8x(
-            src_group.add(wg_index(rem, y_start, rgb_depth, src_stride)),
-            y_group.add(wg_index(rem, y_start, RGB_TO_YUV_WAVES, y_stride)),
-            u_group.add(wg_index(rem, y_start, RGB_TO_YUV_WAVES, u_stride)),
-            v_group.add(wg_index(rem, y_start, RGB_TO_YUV_WAVES, v_stride)),
-            Sampler::BgrOverflow,
-            &y_weights,
-            &u_weights,
-            &v_weights,
-            weights[7] == 1,
-        );
-    }
-}
-
-#[inline]
-#[target_feature(enable = "avx2")]
-unsafe fn yuv_to_rgb_avx2(
-    width: usize,
-    height: usize,
-    src_strides: (usize, usize),
-    src_buffers: (&[u8], &[u8]),
-    dst_stride: usize,
-    dst_buffer: &mut [u8],
-    weights: &[i16; 8],
-) {
-    const SRC_DEPTH: usize = YUV_TO_RGB_WAVES;
-    const DST_DEPTH: usize = 2 * YUV_TO_RGB_WAVES;
-
-    let (y_stride, uv_stride) = src_strides;
-
-    let xxym = _mm256_set1_epi16(weights[0]);
-    let rcrm = _mm256_set1_epi16(weights[1]);
-    let gcrm = _mm256_set1_epi16(weights[2]);
-    let gcbm = _mm256_set1_epi16(weights[3]);
-    let bcbm = _mm256_set1_epi16(weights[4]);
-    let rn = _mm256_set1_epi16(weights[5]);
-    let gp = _mm256_set1_epi16(weights[6]);
-    let bn = _mm256_set1_epi16(weights[7]);
-
-    let y_group = src_buffers.0.as_ptr();
-    let uv_group = src_buffers.1.as_ptr();
-    let dst_group = dst_buffer.as_mut_ptr();
-
-    let wg_width = width / YUV_TO_RGB_WAVES;
-    let wg_height = height / 2;
-
-    for y in 0..wg_height {
-        for x in 0..wg_width {
-            let (cb, cr) =
-                unpack_ui8x2_i16be_16x(uv_group.add(wg_index(x, y, SRC_DEPTH, uv_stride)));
-
-            let sb = _mm256_sub_epi16(_mm256_mulhi_epu16(cb, bcbm), bn);
-            let sr = _mm256_sub_epi16(_mm256_mulhi_epu16(cr, rcrm), rn);
-            let sg = _mm256_sub_epi16(
-                gp,
-                _mm256_add_epi16(_mm256_mulhi_epu16(cb, gcbm), _mm256_mulhi_epu16(cr, gcrm)),
-            );
-
-            let (sb_lo, sb_hi) = i16_to_i16x2_16x(sb);
-            let (sr_lo, sr_hi) = i16_to_i16x2_16x(sr);
-            let (sg_lo, sg_hi) = i16_to_i16x2_16x(sg);
-
-            let y0 = loadu(y_group.add(wg_index(x, 2 * y, SRC_DEPTH, y_stride)).cast());
-
-            let y00 = _mm256_mulhi_epu16(
-                _mm256_permute2x128_si256(
-                    _mm256_unpacklo_epi8(zero!(), y0),
-                    _mm256_unpackhi_epi8(zero!(), y0),
-                    PACK_LO_DQWORD_2X256,
-                ),
-                xxym,
-            );
-            pack_i16x3_16x(
-                dst_group.add(wg_index(2 * x, 2 * y, DST_DEPTH, dst_stride)),
-                fix_to_i16_16x!(_mm256_add_epi16(sr_lo, y00), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sg_lo, y00), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sb_lo, y00), FIX6),
-            );
-
-            let y10 = _mm256_mulhi_epu16(
-                _mm256_permute2x128_si256(
-                    _mm256_unpacklo_epi8(zero!(), y0),
-                    _mm256_unpackhi_epi8(zero!(), y0),
-                    PACK_HI_DQWORD_2X256,
-                ),
-                xxym,
-            );
-            pack_i16x3_16x(
-                dst_group.add(wg_index(2 * x + 1, 2 * y, DST_DEPTH, dst_stride)),
-                fix_to_i16_16x!(_mm256_add_epi16(sr_hi, y10), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sg_hi, y10), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sb_hi, y10), FIX6),
-            );
-
-            let y1 = loadu(
-                y_group
-                    .add(wg_index(x, 2 * y + 1, SRC_DEPTH, y_stride))
-                    .cast(),
-            );
-
-            let y01 = _mm256_mulhi_epu16(
-                _mm256_permute2x128_si256(
-                    _mm256_unpacklo_epi8(zero!(), y1),
-                    _mm256_unpackhi_epi8(zero!(), y1),
-                    PACK_LO_DQWORD_2X256,
-                ),
-                xxym,
-            );
-            pack_i16x3_16x(
-                dst_group.add(wg_index(2 * x, 2 * y + 1, DST_DEPTH, dst_stride)),
-                fix_to_i16_16x!(_mm256_add_epi16(sr_lo, y01), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sg_lo, y01), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sb_lo, y01), FIX6),
-            );
-
-            let y11 = _mm256_mulhi_epu16(
-                _mm256_permute2x128_si256(
-                    _mm256_unpacklo_epi8(zero!(), y1),
-                    _mm256_unpackhi_epi8(zero!(), y1),
-                    PACK_HI_DQWORD_2X256,
-                ),
-                xxym,
-            );
-            pack_i16x3_16x(
-                dst_group.add(wg_index(2 * x + 1, 2 * y + 1, DST_DEPTH, dst_stride)),
-                fix_to_i16_16x!(_mm256_add_epi16(sr_hi, y11), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sg_hi, y11), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sb_hi, y11), FIX6),
-            );
-        }
-    }
-}
-
-#[inline]
-#[target_feature(enable = "avx2")]
-unsafe fn i420_to_rgb_avx2(
-    width: usize,
-    height: usize,
-    src_strides: (usize, usize, usize),
-    src_buffers: (&[u8], &[u8], &[u8]),
-    dst_stride: usize,
-    dst_buffer: &mut [u8],
-    weights: &[i16; 8],
-) {
-    const SRC_DEPTH: usize = YUV_TO_RGB_WAVES;
-    const DST_DEPTH: usize = 2 * YUV_TO_RGB_WAVES;
-
-    let (y_stride, u_stride, v_stride) = src_strides;
-
-    let xxym = _mm256_set1_epi16(weights[0]);
-    let rcrm = _mm256_set1_epi16(weights[1]);
-    let gcrm = _mm256_set1_epi16(weights[2]);
-    let gcbm = _mm256_set1_epi16(weights[3]);
-    let bcbm = _mm256_set1_epi16(weights[4]);
-    let rn = _mm256_set1_epi16(weights[5]);
-    let gp = _mm256_set1_epi16(weights[6]);
-    let bn = _mm256_set1_epi16(weights[7]);
-
-    let y_group = src_buffers.0.as_ptr();
-    let u_group = src_buffers.1.as_ptr();
-    let v_group = src_buffers.2.as_ptr();
-    let dst_group = dst_buffer.as_mut_ptr();
-
-    let wg_width = width / YUV_TO_RGB_WAVES;
-    let wg_height = height / 2;
-
-    for y in 0..wg_height {
-        for x in 0..wg_width {
-            let cb = unpack_ui8_i16be_16x(u_group.add(wg_index(x, y, SRC_DEPTH / 2, u_stride)));
-            let cr = unpack_ui8_i16be_16x(v_group.add(wg_index(x, y, SRC_DEPTH / 2, v_stride)));
-
-            let sb = _mm256_sub_epi16(_mm256_mulhi_epu16(cb, bcbm), bn);
-            let sr = _mm256_sub_epi16(_mm256_mulhi_epu16(cr, rcrm), rn);
-            let sg = _mm256_sub_epi16(
-                gp,
-                _mm256_add_epi16(_mm256_mulhi_epu16(cb, gcbm), _mm256_mulhi_epu16(cr, gcrm)),
-            );
-
-            let (sb_lo, sb_hi) = i16_to_i16x2_16x(sb);
-            let (sr_lo, sr_hi) = i16_to_i16x2_16x(sr);
-            let (sg_lo, sg_hi) = i16_to_i16x2_16x(sg);
-
-            let y0 = loadu(y_group.add(wg_index(x, 2 * y, SRC_DEPTH, y_stride)).cast());
-
-            let y00 = _mm256_mulhi_epu16(
-                _mm256_permute2x128_si256(
-                    _mm256_unpacklo_epi8(zero!(), y0),
-                    _mm256_unpackhi_epi8(zero!(), y0),
-                    PACK_LO_DQWORD_2X256,
-                ),
-                xxym,
-            );
-            pack_i16x3_16x(
-                dst_group.add(wg_index(2 * x, 2 * y, DST_DEPTH, dst_stride)),
-                fix_to_i16_16x!(_mm256_add_epi16(sr_lo, y00), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sg_lo, y00), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sb_lo, y00), FIX6),
-            );
-
-            let y10 = _mm256_mulhi_epu16(
-                _mm256_permute2x128_si256(
-                    _mm256_unpacklo_epi8(zero!(), y0),
-                    _mm256_unpackhi_epi8(zero!(), y0),
-                    PACK_HI_DQWORD_2X256,
-                ),
-                xxym,
-            );
-            pack_i16x3_16x(
-                dst_group.add(wg_index(2 * x + 1, 2 * y, DST_DEPTH, dst_stride)),
-                fix_to_i16_16x!(_mm256_add_epi16(sr_hi, y10), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sg_hi, y10), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sb_hi, y10), FIX6),
-            );
-
-            let y1 = loadu(
-                y_group
-                    .add(wg_index(x, 2 * y + 1, SRC_DEPTH, y_stride))
-                    .cast(),
-            );
-
-            let y01 = _mm256_mulhi_epu16(
-                _mm256_permute2x128_si256(
-                    _mm256_unpacklo_epi8(zero!(), y1),
-                    _mm256_unpackhi_epi8(zero!(), y1),
-                    PACK_LO_DQWORD_2X256,
-                ),
-                xxym,
-            );
-            pack_i16x3_16x(
-                dst_group.add(wg_index(2 * x, 2 * y + 1, DST_DEPTH, dst_stride)),
-                fix_to_i16_16x!(_mm256_add_epi16(sr_lo, y01), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sg_lo, y01), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sb_lo, y01), FIX6),
-            );
-
-            let y11 = _mm256_mulhi_epu16(
-                _mm256_permute2x128_si256(
-                    _mm256_unpacklo_epi8(zero!(), y1),
-                    _mm256_unpackhi_epi8(zero!(), y1),
-                    PACK_HI_DQWORD_2X256,
-                ),
-                xxym,
-            );
-            pack_i16x3_16x(
-                dst_group.add(wg_index(2 * x + 1, 2 * y + 1, DST_DEPTH, dst_stride)),
-                fix_to_i16_16x!(_mm256_add_epi16(sr_hi, y11), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sg_hi, y11), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sb_hi, y11), FIX6),
-            );
-        }
-    }
-}
-
-#[inline]
-#[target_feature(enable = "avx2")]
-unsafe fn i444_to_rgb_avx2(
-    width: usize,
-    height: usize,
-    src_strides: (usize, usize, usize),
-    src_buffers: (&[u8], &[u8], &[u8]),
-    dst_stride: usize,
-    dst_buffer: &mut [u8],
-    weights: &[i16; 8],
-) {
-    const SRC_DEPTH: usize = YUV_TO_RGB_WAVES / 2;
-    const DST_DEPTH: usize = 2 * YUV_TO_RGB_WAVES;
-
-    let (y_stride, u_stride, v_stride) = src_strides;
-
-    let xxym = _mm256_set1_epi16(weights[0]);
-    let rcrm = _mm256_set1_epi16(weights[1]);
-    let gcrm = _mm256_set1_epi16(weights[2]);
-    let gcbm = _mm256_set1_epi16(weights[3]);
-    let bcbm = _mm256_set1_epi16(weights[4]);
-    let rn = _mm256_set1_epi16(weights[5]);
-    let gp = _mm256_set1_epi16(weights[6]);
-    let bn = _mm256_set1_epi16(weights[7]);
-    let zero_128 = _mm_setzero_si128();
-
-    let y_group = src_buffers.0.as_ptr();
-    let u_group = src_buffers.1.as_ptr();
-    let v_group = src_buffers.2.as_ptr();
-    let dst_group = dst_buffer.as_mut_ptr();
-
-    let wg_width = width / SRC_DEPTH;
-
-    for y in 0..height {
-        for x in 0..wg_width {
-            let cb = _mm256_set_m128i(
-                zero_128,
-                loadu(u_group.add(wg_index(x, y, SRC_DEPTH, u_stride)).cast()),
-            );
-            let cr = _mm256_set_m128i(
-                zero_128,
-                loadu(v_group.add(wg_index(x, y, SRC_DEPTH, v_stride)).cast()),
-            );
-            let y0 = _mm256_set_m128i(
-                zero_128,
-                loadu(y_group.add(wg_index(x, y, SRC_DEPTH, y_stride)).cast()),
-            );
-
-            let cb_lo = _mm256_permute2x128_si256(
-                _mm256_unpacklo_epi8(zero!(), cb),
-                _mm256_unpackhi_epi8(zero!(), cb),
-                PACK_LO_DQWORD_2X256,
-            );
-
-            let cr_lo = _mm256_permute2x128_si256(
-                _mm256_unpacklo_epi8(zero!(), cr),
-                _mm256_unpackhi_epi8(zero!(), cr),
-                PACK_LO_DQWORD_2X256,
-            );
-
-            let sb_lo = _mm256_sub_epi16(_mm256_mulhi_epu16(cb_lo, bcbm), bn);
-            let sr_lo = _mm256_sub_epi16(_mm256_mulhi_epu16(cr_lo, rcrm), rn);
-            let sg_lo = _mm256_sub_epi16(
-                gp,
-                _mm256_add_epi16(
-                    _mm256_mulhi_epu16(cb_lo, gcbm),
-                    _mm256_mulhi_epu16(cr_lo, gcrm),
-                ),
-            );
-
-            let y_lo = _mm256_mulhi_epu16(
-                _mm256_permute2x128_si256(
-                    _mm256_unpacklo_epi8(zero!(), y0),
-                    _mm256_unpackhi_epi8(zero!(), y0),
-                    PACK_LO_DQWORD_2X256,
-                ),
-                xxym,
-            );
-            pack_i16x3_16x(
-                dst_group.add(wg_index(x, y, DST_DEPTH, dst_stride)),
-                fix_to_i16_16x!(_mm256_add_epi16(sr_lo, y_lo), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sg_lo, y_lo), FIX6),
-                fix_to_i16_16x!(_mm256_add_epi16(sb_lo, y_lo), FIX6),
-            );
-        }
-    }
-}
-
 // Internal module functions
 #[inline(never)]
-fn nv12_bgra(
+fn nv12_bgra<const COLORIMETRY: usize, const DEPTH: usize>(
     width: u32,
     height: u32,
     last_src_plane: usize,
@@ -1445,10 +1423,7 @@ fn nv12_bgra(
     _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = 4;
-
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
         return true;
@@ -1467,7 +1442,7 @@ fn nv12_bgra(
     let w = width as usize;
     let h = height as usize;
     let ch = h / 2;
-    let rgb_stride = DST_DEPTH * w;
+    let rgb_stride = DEPTH * w;
 
     // Compute actual strides
     let src_strides = (
@@ -1500,21 +1475,20 @@ fn nv12_bgra(
     let scalar_part = w - vector_part;
     if vector_part > 0 {
         unsafe {
-            yuv_to_rgb_avx2(
+            nv12_to_rgb_avx2::<COLORIMETRY>(
                 vector_part,
                 h,
                 src_strides,
                 src_buffers,
                 dst_stride,
                 dst_buffer,
-                &BACKWARD_WEIGHTS[colorimetry],
             );
         }
     }
 
     if scalar_part > 0 {
         let x = vector_part;
-        let dx = x * DST_DEPTH;
+        let dx = x * DEPTH;
 
         // The compiler is not smart here
         // This condition should never happen
@@ -1522,14 +1496,13 @@ fn nv12_bgra(
             return false;
         }
 
-        x86::nv12_to_rgb(
+        x86::nv12_to_rgb::<COLORIMETRY, DEPTH>(
             scalar_part,
             h,
             src_strides,
             (&src_buffers.0[x..], &src_buffers.1[x..]),
             dst_stride,
             &mut dst_buffer[dx..],
-            &x86::BACKWARD_WEIGHTS[colorimetry],
         );
     }
 
@@ -1537,7 +1510,7 @@ fn nv12_bgra(
 }
 
 #[inline(never)]
-fn i420_bgra(
+fn i420_bgra<const COLORIMETRY: usize, const DEPTH: usize>(
     width: u32,
     height: u32,
     _last_src_plane: usize,
@@ -1546,10 +1519,7 @@ fn i420_bgra(
     _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = 4;
-
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
         return true;
@@ -1569,7 +1539,7 @@ fn i420_bgra(
     let h = height as usize;
     let cw = w / 2;
     let ch = h / 2;
-    let rgb_stride = DST_DEPTH * w;
+    let rgb_stride = DEPTH * w;
 
     // Compute actual strides
     let src_strides = (
@@ -1596,14 +1566,13 @@ fn i420_bgra(
     let scalar_part = w - vector_part;
     if vector_part > 0 {
         unsafe {
-            i420_to_rgb_avx2(
+            i420_to_rgb_avx2::<COLORIMETRY>(
                 vector_part,
                 h,
                 src_strides,
                 src_buffers,
                 dst_stride,
                 dst_buffer,
-                &BACKWARD_WEIGHTS[colorimetry],
             );
         }
     }
@@ -1611,7 +1580,7 @@ fn i420_bgra(
     if scalar_part > 0 {
         let x = vector_part;
         let cx = x / 2;
-        let dx = x * DST_DEPTH;
+        let dx = x * DEPTH;
 
         // The compiler is not smart here
         // This condition should never happen
@@ -1623,7 +1592,7 @@ fn i420_bgra(
             return false;
         }
 
-        x86::i420_to_rgb(
+        x86::i420_to_rgb::<COLORIMETRY, DEPTH>(
             scalar_part,
             h,
             src_strides,
@@ -1634,7 +1603,6 @@ fn i420_bgra(
             ),
             dst_stride,
             &mut dst_buffer[dx..],
-            &x86::BACKWARD_WEIGHTS[colorimetry],
         );
     }
 
@@ -1642,7 +1610,7 @@ fn i420_bgra(
 }
 
 #[inline(never)]
-fn i444_bgra(
+fn i444_bgra<const COLORIMETRY: usize, const DEPTH: usize>(
     width: u32,
     height: u32,
     _last_src_plane: usize,
@@ -1651,10 +1619,7 @@ fn i444_bgra(
     _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    colorimetry: usize,
 ) -> bool {
-    const DST_DEPTH: usize = 4;
-
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
         return true;
@@ -1671,7 +1636,7 @@ fn i444_bgra(
 
     let w = width as usize;
     let h = height as usize;
-    let rgb_stride = DST_DEPTH * w;
+    let rgb_stride = DEPTH * w;
 
     // Compute actual strides
     let src_strides = (
@@ -1698,21 +1663,20 @@ fn i444_bgra(
     let scalar_part = w - vector_part;
     if vector_part > 0 {
         unsafe {
-            i444_to_rgb_avx2(
+            i444_to_rgb_avx2::<COLORIMETRY>(
                 vector_part,
                 h,
                 src_strides,
                 src_buffers,
                 dst_stride,
                 dst_buffer,
-                &BACKWARD_WEIGHTS[colorimetry],
             );
         }
     }
 
     if scalar_part > 0 {
         let x = vector_part;
-        let dx = x * DST_DEPTH;
+        let dx = x * DEPTH;
 
         // The compiler is not smart here
         // This condition should never happen
@@ -1724,7 +1688,7 @@ fn i444_bgra(
             return false;
         }
 
-        x86::i444_to_rgb(
+        x86::i444_to_rgb::<COLORIMETRY, DEPTH>(
             scalar_part,
             h,
             src_strides,
@@ -1735,7 +1699,6 @@ fn i444_bgra(
             ),
             dst_stride,
             &mut dst_buffer[dx..],
-            &x86::BACKWARD_WEIGHTS[colorimetry],
         );
     }
 
@@ -1743,7 +1706,7 @@ fn i444_bgra(
 }
 
 #[inline(never)]
-fn rgb_nv12(
+fn rgb_nv12<const SAMPLER: usize, const DEPTH: usize, const COLORIMETRY: usize>(
     width: u32,
     height: u32,
     _last_src_plane: usize,
@@ -1752,8 +1715,6 @@ fn rgb_nv12(
     last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    colorimetry: usize,
-    sampler: Sampler,
 ) -> bool {
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1772,11 +1733,7 @@ fn rgb_nv12(
     let w = width as usize;
     let h = height as usize;
     let ch = h / 2;
-    let depth = match sampler {
-        Sampler::Bgr => 3_usize,
-        _ => 4_usize,
-    };
-    let rgb_stride = depth * w;
+    let rgb_stride = DEPTH * w;
 
     // Compute actual strides
     let src_stride = compute_stride(src_strides[0], rgb_stride);
@@ -1812,23 +1769,20 @@ fn rgb_nv12(
     let scalar_part = w - vector_part;
     if vector_part > 0 {
         unsafe {
-            rgb_to_yuv_avx2(
+            rgb_to_nv12_avx2::<SAMPLER, DEPTH, COLORIMETRY>(
                 vector_part,
                 h,
                 src_stride,
                 src_buffer,
                 dst_strides,
                 &mut (y_plane, uv_plane),
-                depth,
-                &FORWARD_WEIGHTS[colorimetry],
-                sampler,
             );
         }
     }
 
     if scalar_part > 0 {
         let x = vector_part;
-        let sx = x * depth;
+        let sx = x * DEPTH;
 
         // The compiler is not smart here
         // This condition should never happen
@@ -1836,16 +1790,13 @@ fn rgb_nv12(
             return false;
         }
 
-        x86::rgb_to_nv12(
+        x86::rgb_to_nv12::<SAMPLER, DEPTH, COLORIMETRY>(
             scalar_part,
             h,
             src_stride,
             &src_buffer[sx..],
             dst_strides,
             &mut (&mut y_plane[x..], &mut uv_plane[x..]),
-            depth,
-            &x86::FORWARD_WEIGHTS[colorimetry],
-            sampler,
         );
     }
 
@@ -1853,7 +1804,7 @@ fn rgb_nv12(
 }
 
 #[inline(never)]
-fn rgb_i420(
+fn rgb_i420<const SAMPLER: usize, const DEPTH: usize, const COLORIMETRY: usize>(
     width: u32,
     height: u32,
     _last_src_plane: usize,
@@ -1862,8 +1813,6 @@ fn rgb_i420(
     _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    colorimetry: usize,
-    sampler: Sampler,
 ) -> bool {
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1883,11 +1832,7 @@ fn rgb_i420(
     let h = height as usize;
     let cw = w / 2;
     let ch = h / 2;
-    let depth = match sampler {
-        Sampler::Bgr => 3_usize,
-        _ => 4_usize,
-    };
-    let rgb_stride = depth * w;
+    let rgb_stride = DEPTH * w;
 
     // Compute actual strides
     let src_stride = compute_stride(src_strides[0], rgb_stride);
@@ -1916,16 +1861,13 @@ fn rgb_i420(
     let scalar_part = w - vector_part;
     if vector_part > 0 {
         unsafe {
-            rgb_to_i420_avx2(
+            rgb_to_i420_avx2::<SAMPLER, DEPTH, COLORIMETRY>(
                 vector_part,
                 h,
                 src_stride,
                 src_buffer,
                 dst_strides,
                 &mut (y_plane, u_plane, v_plane),
-                depth,
-                &FORWARD_WEIGHTS[colorimetry],
-                sampler,
             );
         }
     }
@@ -1933,7 +1875,7 @@ fn rgb_i420(
     if scalar_part > 0 {
         let x = vector_part;
         let cx = x / 2;
-        let sx = x * depth;
+        let sx = x * DEPTH;
 
         // The compiler is not smart here
         // This condition should never happen
@@ -1945,16 +1887,13 @@ fn rgb_i420(
             return false;
         }
 
-        x86::rgb_to_i420(
+        x86::rgb_to_i420::<SAMPLER, DEPTH, COLORIMETRY>(
             scalar_part,
             h,
             src_stride,
             &src_buffer[sx..],
             dst_strides,
             &mut (&mut y_plane[x..], &mut u_plane[cx..], &mut v_plane[cx..]),
-            depth,
-            &x86::FORWARD_WEIGHTS[colorimetry],
-            sampler,
         );
     }
 
@@ -1962,7 +1901,7 @@ fn rgb_i420(
 }
 
 #[inline(never)]
-fn rgb_i444(
+fn rgb_i444<const SAMPLER: usize, const DEPTH: usize, const COLORIMETRY: usize>(
     width: u32,
     height: u32,
     _last_src_plane: usize,
@@ -1971,8 +1910,6 @@ fn rgb_i444(
     _last_dst_plane: usize,
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
-    colorimetry: usize,
-    sampler: Sampler,
 ) -> bool {
     // Degenerate case, trivially accept
     if width == 0 || height == 0 {
@@ -1990,11 +1927,7 @@ fn rgb_i444(
 
     let w = width as usize;
     let h = height as usize;
-    let depth = match sampler {
-        Sampler::Bgr => 3_usize,
-        _ => 4_usize,
-    };
-    let rgb_stride = depth * w;
+    let rgb_stride = DEPTH * w;
 
     // Compute actual strides
     let src_stride = compute_stride(src_strides[0], rgb_stride);
@@ -2023,23 +1956,20 @@ fn rgb_i444(
     let scalar_part = w - vector_part;
     if vector_part > 0 {
         unsafe {
-            rgb_to_i444_avx2(
+            rgb_to_i444_avx2::<SAMPLER, DEPTH, COLORIMETRY>(
                 vector_part,
                 h,
                 src_stride,
                 src_buffer,
                 dst_strides,
                 &mut (y_plane, u_plane, v_plane),
-                depth,
-                &FORWARD_WEIGHTS[colorimetry],
-                sampler,
             );
         }
     }
 
     if scalar_part > 0 {
         let x = vector_part;
-        let sx = x * depth;
+        let sx = x * DEPTH;
 
         // The compiler is not smart here
         // This condition should never happen
@@ -2048,16 +1978,13 @@ fn rgb_i444(
             return false;
         }
 
-        x86::rgb_to_i444(
+        x86::rgb_to_i444::<SAMPLER, DEPTH, COLORIMETRY>(
             scalar_part,
             h,
             src_stride,
             &src_buffer[sx..],
             dst_strides,
             &mut (&mut y_plane[x..], &mut u_plane[x..], &mut v_plane[x..]),
-            depth,
-            &x86::FORWARD_WEIGHTS[colorimetry],
-            sampler,
         );
     }
 

--- a/src/convert_image/common.rs
+++ b/src/convert_image/common.rs
@@ -20,6 +20,20 @@ const fn u8_to_fix(x: i32, frac_bits: i32) -> i32 {
 }
 
 #[cfg(not(tarpaulin_include))]
+pub const fn sampler_to_depth(sampler: Sampler) -> usize {
+    match sampler {
+        Sampler::Bgr | Sampler::BgrOverflow => 3,
+        _ => 4,
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
+pub const fn is_full_range<const COLORIMETRY: usize>() -> bool {
+    // Forward weights should be defined to mach this order
+    COLORIMETRY >= 2
+}
+
+#[cfg(not(tarpaulin_include))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
 pub const fn i32x2_to_i32(x: i32, y: i32) -> i32 {

--- a/src/convert_image/common.rs
+++ b/src/convert_image/common.rs
@@ -178,8 +178,3 @@ pub enum Colorimetry {
     Bt709FR,
     Length,
 }
-
-pub enum PixelFormatChannels {
-    Three = 3,
-    Four = 4,
-}

--- a/src/convert_image/x86.rs
+++ b/src/convert_image/x86.rs
@@ -178,7 +178,7 @@ unsafe fn pack_ui8x3(image: *mut u8, x: u8, y: u8, z: u8) {
 }
 
 #[inline(never)]
-pub fn lrgb_to_nv12(
+pub fn rgb_to_nv12(
     width: usize,
     height: usize,
     src_stride: usize,
@@ -261,7 +261,7 @@ pub fn lrgb_to_nv12(
 }
 
 #[inline(never)]
-pub fn lrgb_to_i420(
+pub fn rgb_to_i420(
     width: usize,
     height: usize,
     src_stride: usize,
@@ -348,7 +348,7 @@ pub fn lrgb_to_i420(
 }
 
 #[inline(never)]
-pub fn lrgb_to_i444(
+pub fn rgb_to_i444(
     width: usize,
     height: usize,
     src_stride: usize,
@@ -401,7 +401,7 @@ pub fn lrgb_to_i444(
 }
 
 #[inline(never)]
-pub fn i444_to_lrgb(
+pub fn i444_to_rgb(
     width: usize,
     height: usize,
     src_strides: (usize, usize, usize),
@@ -452,7 +452,7 @@ pub fn i444_to_lrgb(
 }
 
 #[inline(never)]
-pub fn nv12_to_lrgb(
+pub fn nv12_to_rgb(
     width: usize,
     height: usize,
     src_strides: (usize, usize),
@@ -549,7 +549,7 @@ pub fn nv12_to_lrgb(
 }
 
 #[inline(never)]
-pub fn i420_to_lrgb(
+pub fn i420_to_rgb(
     width: usize,
     height: usize,
     src_strides: (usize, usize, usize),
@@ -921,7 +921,7 @@ pub fn rgb_to_bgra(
 }
 
 #[inline(never)]
-fn nv12_bgra_lrgb(
+fn nv12_bgra_rgb(
     width: u32,
     height: u32,
     last_src_plane: usize,
@@ -979,7 +979,7 @@ fn nv12_bgra_lrgb(
         return false;
     }
 
-    nv12_to_lrgb(
+    nv12_to_rgb(
         w,
         h,
         src_strides,
@@ -993,7 +993,7 @@ fn nv12_bgra_lrgb(
 }
 
 #[inline(never)]
-fn i420_bgra_lrgb(
+fn i420_bgra_rgb(
     width: u32,
     height: u32,
     src_strides: &[usize],
@@ -1045,7 +1045,7 @@ fn i420_bgra_lrgb(
         return false;
     }
 
-    i420_to_lrgb(
+    i420_to_rgb(
         w,
         h,
         src_strides,
@@ -1059,7 +1059,7 @@ fn i420_bgra_lrgb(
 }
 
 #[inline(never)]
-fn i444_bgra_lrgb(
+fn i444_bgra_rgb(
     width: u32,
     height: u32,
     src_strides: &[usize],
@@ -1108,7 +1108,7 @@ fn i444_bgra_lrgb(
         return false;
     }
 
-    i444_to_lrgb(
+    i444_to_rgb(
         w,
         h,
         src_strides,
@@ -1122,7 +1122,7 @@ fn i444_bgra_lrgb(
 }
 
 #[inline(never)]
-fn lrgb_i444(
+fn rgb_i444(
     width: u32,
     height: u32,
     src_strides: &[usize],
@@ -1174,7 +1174,7 @@ fn lrgb_i444(
         return false;
     }
 
-    lrgb_to_i444(
+    rgb_to_i444(
         w,
         h,
         src_stride,
@@ -1190,7 +1190,7 @@ fn lrgb_i444(
 }
 
 #[inline(never)]
-fn lrgb_i420(
+fn rgb_i420(
     width: u32,
     height: u32,
     src_strides: &[usize],
@@ -1244,7 +1244,7 @@ fn lrgb_i420(
         return false;
     }
 
-    lrgb_to_i420(
+    rgb_to_i420(
         w,
         h,
         src_stride,
@@ -1260,7 +1260,7 @@ fn lrgb_i420(
 }
 
 #[inline(never)]
-fn lrgb_nv12(
+fn rgb_nv12(
     width: u32,
     height: u32,
     src_strides: &[usize],
@@ -1321,7 +1321,7 @@ fn lrgb_nv12(
         return false;
     }
 
-    lrgb_to_nv12(
+    rgb_to_nv12(
         w,
         h,
         src_stride,
@@ -1336,7 +1336,7 @@ fn lrgb_nv12(
     true
 }
 
-pub fn rgb_lrgb_bgra_lrgb(
+pub fn rgb_rgb_bgra_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1385,7 +1385,7 @@ pub fn rgb_lrgb_bgra_lrgb(
     true
 }
 
-pub fn argb_lrgb_nv12_bt601(
+pub fn argb_rgb_nv12_bt601(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1395,7 +1395,7 @@ pub fn argb_lrgb_nv12_bt601(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -1409,7 +1409,7 @@ pub fn argb_lrgb_nv12_bt601(
     )
 }
 
-pub fn argb_lrgb_nv12_bt709(
+pub fn argb_rgb_nv12_bt709(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1419,7 +1419,7 @@ pub fn argb_lrgb_nv12_bt709(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -1433,7 +1433,7 @@ pub fn argb_lrgb_nv12_bt709(
     )
 }
 
-pub fn bgra_lrgb_nv12_bt601(
+pub fn bgra_rgb_nv12_bt601(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1443,7 +1443,7 @@ pub fn bgra_lrgb_nv12_bt601(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -1457,7 +1457,7 @@ pub fn bgra_lrgb_nv12_bt601(
     )
 }
 
-pub fn bgra_lrgb_nv12_bt709(
+pub fn bgra_rgb_nv12_bt709(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1467,7 +1467,7 @@ pub fn bgra_lrgb_nv12_bt709(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -1481,7 +1481,7 @@ pub fn bgra_lrgb_nv12_bt709(
     )
 }
 
-pub fn bgr_lrgb_nv12_bt601(
+pub fn bgr_rgb_nv12_bt601(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1491,7 +1491,7 @@ pub fn bgr_lrgb_nv12_bt601(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -1505,7 +1505,7 @@ pub fn bgr_lrgb_nv12_bt601(
     )
 }
 
-pub fn bgr_lrgb_nv12_bt709(
+pub fn bgr_rgb_nv12_bt709(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1515,7 +1515,7 @@ pub fn bgr_lrgb_nv12_bt709(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -1529,7 +1529,7 @@ pub fn bgr_lrgb_nv12_bt709(
     )
 }
 
-pub fn bgr_lrgb_rgb_lrgb(
+pub fn bgr_rgb_rgb_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1577,7 +1577,7 @@ pub fn bgr_lrgb_rgb_lrgb(
     true
 }
 
-pub fn nv12_bt601_bgra_lrgb(
+pub fn nv12_bt601_bgra_rgb(
     width: u32,
     height: u32,
     last_src_plane: u32,
@@ -1587,7 +1587,7 @@ pub fn nv12_bt601_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    nv12_bgra_lrgb(
+    nv12_bgra_rgb(
         width,
         height,
         last_src_plane as usize,
@@ -1599,7 +1599,7 @@ pub fn nv12_bt601_bgra_lrgb(
     )
 }
 
-pub fn nv12_bt709_bgra_lrgb(
+pub fn nv12_bt709_bgra_rgb(
     width: u32,
     height: u32,
     last_src_plane: u32,
@@ -1609,7 +1609,7 @@ pub fn nv12_bt709_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    nv12_bgra_lrgb(
+    nv12_bgra_rgb(
         width,
         height,
         last_src_plane as usize,
@@ -1621,7 +1621,7 @@ pub fn nv12_bt709_bgra_lrgb(
     )
 }
 
-pub fn i420_bt601_bgra_lrgb(
+pub fn i420_bt601_bgra_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1631,7 +1631,7 @@ pub fn i420_bt601_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    i420_bgra_lrgb(
+    i420_bgra_rgb(
         width,
         height,
         src_strides,
@@ -1642,7 +1642,7 @@ pub fn i420_bt601_bgra_lrgb(
     )
 }
 
-pub fn i420_bt709_bgra_lrgb(
+pub fn i420_bt709_bgra_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1652,7 +1652,7 @@ pub fn i420_bt709_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    i420_bgra_lrgb(
+    i420_bgra_rgb(
         width,
         height,
         src_strides,
@@ -1663,7 +1663,7 @@ pub fn i420_bt709_bgra_lrgb(
     )
 }
 
-pub fn i444_bt601_bgra_lrgb(
+pub fn i444_bt601_bgra_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1673,7 +1673,7 @@ pub fn i444_bt601_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    i444_bgra_lrgb(
+    i444_bgra_rgb(
         width,
         height,
         src_strides,
@@ -1684,7 +1684,7 @@ pub fn i444_bt601_bgra_lrgb(
     )
 }
 
-pub fn i444_bt709_bgra_lrgb(
+pub fn i444_bt709_bgra_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1694,7 +1694,7 @@ pub fn i444_bt709_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    i444_bgra_lrgb(
+    i444_bgra_rgb(
         width,
         height,
         src_strides,
@@ -1705,7 +1705,7 @@ pub fn i444_bt709_bgra_lrgb(
     )
 }
 
-pub fn argb_lrgb_i420_bt601(
+pub fn argb_rgb_i420_bt601(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1715,7 +1715,7 @@ pub fn argb_lrgb_i420_bt601(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i420(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -1728,7 +1728,7 @@ pub fn argb_lrgb_i420_bt601(
     )
 }
 
-pub fn argb_lrgb_i420_bt709(
+pub fn argb_rgb_i420_bt709(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1738,7 +1738,7 @@ pub fn argb_lrgb_i420_bt709(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i420(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -1751,7 +1751,7 @@ pub fn argb_lrgb_i420_bt709(
     )
 }
 
-pub fn bgra_lrgb_i420_bt601(
+pub fn bgra_rgb_i420_bt601(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1761,7 +1761,7 @@ pub fn bgra_lrgb_i420_bt601(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i420(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -1774,7 +1774,7 @@ pub fn bgra_lrgb_i420_bt601(
     )
 }
 
-pub fn bgra_lrgb_i420_bt709(
+pub fn bgra_rgb_i420_bt709(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1784,7 +1784,7 @@ pub fn bgra_lrgb_i420_bt709(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i420(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -1797,7 +1797,7 @@ pub fn bgra_lrgb_i420_bt709(
     )
 }
 
-pub fn bgr_lrgb_i420_bt601(
+pub fn bgr_rgb_i420_bt601(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1807,7 +1807,7 @@ pub fn bgr_lrgb_i420_bt601(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i420(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -1820,7 +1820,7 @@ pub fn bgr_lrgb_i420_bt601(
     )
 }
 
-pub fn bgr_lrgb_i420_bt709(
+pub fn bgr_rgb_i420_bt709(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1830,7 +1830,7 @@ pub fn bgr_lrgb_i420_bt709(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i420(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -1843,7 +1843,7 @@ pub fn bgr_lrgb_i420_bt709(
     )
 }
 
-pub fn argb_lrgb_i444_bt601(
+pub fn argb_rgb_i444_bt601(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1853,7 +1853,7 @@ pub fn argb_lrgb_i444_bt601(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i444(
+    rgb_i444(
         width,
         height,
         src_strides,
@@ -1866,7 +1866,7 @@ pub fn argb_lrgb_i444_bt601(
     )
 }
 
-pub fn argb_lrgb_i444_bt709(
+pub fn argb_rgb_i444_bt709(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1876,7 +1876,7 @@ pub fn argb_lrgb_i444_bt709(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i444(
+    rgb_i444(
         width,
         height,
         src_strides,
@@ -1889,7 +1889,7 @@ pub fn argb_lrgb_i444_bt709(
     )
 }
 
-pub fn bgra_lrgb_i444_bt601(
+pub fn bgra_rgb_i444_bt601(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1899,7 +1899,7 @@ pub fn bgra_lrgb_i444_bt601(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i444(
+    rgb_i444(
         width,
         height,
         src_strides,
@@ -1912,7 +1912,7 @@ pub fn bgra_lrgb_i444_bt601(
     )
 }
 
-pub fn bgra_lrgb_i444_bt709(
+pub fn bgra_rgb_i444_bt709(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1922,7 +1922,7 @@ pub fn bgra_lrgb_i444_bt709(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i444(
+    rgb_i444(
         width,
         height,
         src_strides,
@@ -1935,7 +1935,7 @@ pub fn bgra_lrgb_i444_bt709(
     )
 }
 
-pub fn bgr_lrgb_i444_bt601(
+pub fn bgr_rgb_i444_bt601(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1945,7 +1945,7 @@ pub fn bgr_lrgb_i444_bt601(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i444(
+    rgb_i444(
         width,
         height,
         src_strides,
@@ -1958,7 +1958,7 @@ pub fn bgr_lrgb_i444_bt601(
     )
 }
 
-pub fn bgr_lrgb_i444_bt709(
+pub fn bgr_rgb_i444_bt709(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -1968,7 +1968,7 @@ pub fn bgr_lrgb_i444_bt709(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i444(
+    rgb_i444(
         width,
         height,
         src_strides,
@@ -1981,7 +1981,7 @@ pub fn bgr_lrgb_i444_bt709(
     )
 }
 
-pub fn bgra_lrgb_rgb_lrgb(
+pub fn bgra_rgb_rgb_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2030,7 +2030,7 @@ pub fn bgra_lrgb_rgb_lrgb(
     true
 }
 
-pub fn argb_lrgb_nv12_bt601fr(
+pub fn argb_rgb_nv12_bt601fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2040,7 +2040,7 @@ pub fn argb_lrgb_nv12_bt601fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -2054,7 +2054,7 @@ pub fn argb_lrgb_nv12_bt601fr(
     )
 }
 
-pub fn bgra_lrgb_nv12_bt601fr(
+pub fn bgra_rgb_nv12_bt601fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2064,7 +2064,7 @@ pub fn bgra_lrgb_nv12_bt601fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -2078,7 +2078,7 @@ pub fn bgra_lrgb_nv12_bt601fr(
     )
 }
 
-pub fn bgr_lrgb_nv12_bt601fr(
+pub fn bgr_rgb_nv12_bt601fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2088,7 +2088,7 @@ pub fn bgr_lrgb_nv12_bt601fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -2102,7 +2102,7 @@ pub fn bgr_lrgb_nv12_bt601fr(
     )
 }
 
-pub fn nv12_bt601fr_bgra_lrgb(
+pub fn nv12_bt601fr_bgra_rgb(
     width: u32,
     height: u32,
     last_src_plane: u32,
@@ -2112,7 +2112,7 @@ pub fn nv12_bt601fr_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    nv12_bgra_lrgb(
+    nv12_bgra_rgb(
         width,
         height,
         last_src_plane as usize,
@@ -2124,7 +2124,7 @@ pub fn nv12_bt601fr_bgra_lrgb(
     )
 }
 
-pub fn i420_bt601fr_bgra_lrgb(
+pub fn i420_bt601fr_bgra_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2134,7 +2134,7 @@ pub fn i420_bt601fr_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    i420_bgra_lrgb(
+    i420_bgra_rgb(
         width,
         height,
         src_strides,
@@ -2145,7 +2145,7 @@ pub fn i420_bt601fr_bgra_lrgb(
     )
 }
 
-pub fn i444_bt601fr_bgra_lrgb(
+pub fn i444_bt601fr_bgra_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2155,7 +2155,7 @@ pub fn i444_bt601fr_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    i444_bgra_lrgb(
+    i444_bgra_rgb(
         width,
         height,
         src_strides,
@@ -2166,7 +2166,7 @@ pub fn i444_bt601fr_bgra_lrgb(
     )
 }
 
-pub fn argb_lrgb_i420_bt601fr(
+pub fn argb_rgb_i420_bt601fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2176,76 +2176,7 @@ pub fn argb_lrgb_i420_bt601fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Argb,
-    )
-}
-
-pub fn bgra_lrgb_i420_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Four,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgra,
-    )
-}
-
-pub fn bgr_lrgb_i420_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i420(
-        width,
-        height,
-        src_strides,
-        src_buffers,
-        dst_strides,
-        dst_buffers,
-        PixelFormatChannels::Three,
-        Colorimetry::Bt601FR as usize,
-        Sampler::Bgr,
-    )
-}
-
-pub fn argb_lrgb_i444_bt601fr(
-    width: u32,
-    height: u32,
-    _last_src_plane: u32,
-    src_strides: &[usize],
-    src_buffers: &[&[u8]],
-    _last_dst_plane: u32,
-    dst_strides: &[usize],
-    dst_buffers: &mut [&mut [u8]],
-) -> bool {
-    lrgb_i444(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -2258,7 +2189,7 @@ pub fn argb_lrgb_i444_bt601fr(
     )
 }
 
-pub fn bgra_lrgb_i444_bt601fr(
+pub fn bgra_rgb_i420_bt601fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2268,7 +2199,7 @@ pub fn bgra_lrgb_i444_bt601fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i444(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -2281,7 +2212,7 @@ pub fn bgra_lrgb_i444_bt601fr(
     )
 }
 
-pub fn bgr_lrgb_i444_bt601fr(
+pub fn bgr_rgb_i420_bt601fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2291,7 +2222,7 @@ pub fn bgr_lrgb_i444_bt601fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i444(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -2304,7 +2235,76 @@ pub fn bgr_lrgb_i444_bt601fr(
     )
 }
 
-pub fn argb_lrgb_nv12_bt709fr(
+pub fn argb_rgb_i444_bt601fr(
+    width: u32,
+    height: u32,
+    _last_src_plane: u32,
+    src_strides: &[usize],
+    src_buffers: &[&[u8]],
+    _last_dst_plane: u32,
+    dst_strides: &[usize],
+    dst_buffers: &mut [&mut [u8]],
+) -> bool {
+    rgb_i444(
+        width,
+        height,
+        src_strides,
+        src_buffers,
+        dst_strides,
+        dst_buffers,
+        PixelFormatChannels::Four,
+        Colorimetry::Bt601FR as usize,
+        Sampler::Argb,
+    )
+}
+
+pub fn bgra_rgb_i444_bt601fr(
+    width: u32,
+    height: u32,
+    _last_src_plane: u32,
+    src_strides: &[usize],
+    src_buffers: &[&[u8]],
+    _last_dst_plane: u32,
+    dst_strides: &[usize],
+    dst_buffers: &mut [&mut [u8]],
+) -> bool {
+    rgb_i444(
+        width,
+        height,
+        src_strides,
+        src_buffers,
+        dst_strides,
+        dst_buffers,
+        PixelFormatChannels::Four,
+        Colorimetry::Bt601FR as usize,
+        Sampler::Bgra,
+    )
+}
+
+pub fn bgr_rgb_i444_bt601fr(
+    width: u32,
+    height: u32,
+    _last_src_plane: u32,
+    src_strides: &[usize],
+    src_buffers: &[&[u8]],
+    _last_dst_plane: u32,
+    dst_strides: &[usize],
+    dst_buffers: &mut [&mut [u8]],
+) -> bool {
+    rgb_i444(
+        width,
+        height,
+        src_strides,
+        src_buffers,
+        dst_strides,
+        dst_buffers,
+        PixelFormatChannels::Three,
+        Colorimetry::Bt601FR as usize,
+        Sampler::Bgr,
+    )
+}
+
+pub fn argb_rgb_nv12_bt709fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2314,7 +2314,7 @@ pub fn argb_lrgb_nv12_bt709fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -2328,7 +2328,7 @@ pub fn argb_lrgb_nv12_bt709fr(
     )
 }
 
-pub fn bgra_lrgb_nv12_bt709fr(
+pub fn bgra_rgb_nv12_bt709fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2338,7 +2338,7 @@ pub fn bgra_lrgb_nv12_bt709fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -2352,7 +2352,7 @@ pub fn bgra_lrgb_nv12_bt709fr(
     )
 }
 
-pub fn bgr_lrgb_nv12_bt709fr(
+pub fn bgr_rgb_nv12_bt709fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2362,7 +2362,7 @@ pub fn bgr_lrgb_nv12_bt709fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_nv12(
+    rgb_nv12(
         width,
         height,
         src_strides,
@@ -2376,7 +2376,7 @@ pub fn bgr_lrgb_nv12_bt709fr(
     )
 }
 
-pub fn nv12_bt709fr_bgra_lrgb(
+pub fn nv12_bt709fr_bgra_rgb(
     width: u32,
     height: u32,
     last_src_plane: u32,
@@ -2386,7 +2386,7 @@ pub fn nv12_bt709fr_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    nv12_bgra_lrgb(
+    nv12_bgra_rgb(
         width,
         height,
         last_src_plane as usize,
@@ -2398,7 +2398,7 @@ pub fn nv12_bt709fr_bgra_lrgb(
     )
 }
 
-pub fn i420_bt709fr_bgra_lrgb(
+pub fn i420_bt709fr_bgra_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2408,7 +2408,7 @@ pub fn i420_bt709fr_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    i420_bgra_lrgb(
+    i420_bgra_rgb(
         width,
         height,
         src_strides,
@@ -2419,7 +2419,7 @@ pub fn i420_bt709fr_bgra_lrgb(
     )
 }
 
-pub fn i444_bt709fr_bgra_lrgb(
+pub fn i444_bt709fr_bgra_rgb(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2429,7 +2429,7 @@ pub fn i444_bt709fr_bgra_lrgb(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    i444_bgra_lrgb(
+    i444_bgra_rgb(
         width,
         height,
         src_strides,
@@ -2440,7 +2440,7 @@ pub fn i444_bt709fr_bgra_lrgb(
     )
 }
 
-pub fn argb_lrgb_i420_bt709fr(
+pub fn argb_rgb_i420_bt709fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2450,7 +2450,7 @@ pub fn argb_lrgb_i420_bt709fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i420(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -2463,7 +2463,7 @@ pub fn argb_lrgb_i420_bt709fr(
     )
 }
 
-pub fn bgra_lrgb_i420_bt709fr(
+pub fn bgra_rgb_i420_bt709fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2473,7 +2473,7 @@ pub fn bgra_lrgb_i420_bt709fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i420(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -2486,7 +2486,7 @@ pub fn bgra_lrgb_i420_bt709fr(
     )
 }
 
-pub fn bgr_lrgb_i420_bt709fr(
+pub fn bgr_rgb_i420_bt709fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2496,7 +2496,7 @@ pub fn bgr_lrgb_i420_bt709fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i420(
+    rgb_i420(
         width,
         height,
         src_strides,
@@ -2509,7 +2509,7 @@ pub fn bgr_lrgb_i420_bt709fr(
     )
 }
 
-pub fn argb_lrgb_i444_bt709fr(
+pub fn argb_rgb_i444_bt709fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2519,7 +2519,7 @@ pub fn argb_lrgb_i444_bt709fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i444(
+    rgb_i444(
         width,
         height,
         src_strides,
@@ -2532,7 +2532,7 @@ pub fn argb_lrgb_i444_bt709fr(
     )
 }
 
-pub fn bgra_lrgb_i444_bt709fr(
+pub fn bgra_rgb_i444_bt709fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2542,7 +2542,7 @@ pub fn bgra_lrgb_i444_bt709fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i444(
+    rgb_i444(
         width,
         height,
         src_strides,
@@ -2555,7 +2555,7 @@ pub fn bgra_lrgb_i444_bt709fr(
     )
 }
 
-pub fn bgr_lrgb_i444_bt709fr(
+pub fn bgr_rgb_i444_bt709fr(
     width: u32,
     height: u32,
     _last_src_plane: u32,
@@ -2565,7 +2565,7 @@ pub fn bgr_lrgb_i444_bt709fr(
     dst_strides: &[usize],
     dst_buffers: &mut [&mut [u8]],
 ) -> bool {
-    lrgb_i444(
+    rgb_i444(
         width,
         height,
         src_strides,

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -17,6 +17,69 @@ use crate::color_space::ColorSpace;
 use crate::pixel_format::PixelFormat;
 use crate::static_assert;
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! rgb_to_yuv_converter {
+    ($src_pf:ident, $dst_pf:ident, $dst_cs:ident) => {
+        paste::paste! {
+            pub fn [<$src_pf:lower _ $dst_pf:lower _ $dst_cs:lower>](
+                width: u32,
+                height: u32,
+                last_src_plane: u32,
+                src_strides: &[usize],
+                src_buffers: &[&[u8]],
+                last_dst_plane: u32,
+                dst_strides: &[usize],
+                dst_buffers: &mut [&mut [u8]],
+            ) -> bool {
+                [<rgb _ $dst_pf:lower>](
+                    width,
+                    height,
+                    last_src_plane as usize,
+                    src_strides,
+                    src_buffers,
+                    last_dst_plane as usize,
+                    dst_strides,
+                    dst_buffers,
+                    Colorimetry::$dst_cs as usize,
+                    Sampler::$src_pf,
+                )
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! yuv_to_rgb_converter {
+    ($src_pf:ident, $src_cs:ident) => {
+        paste::paste! {
+            pub fn [<$src_pf:lower _ $src_cs:lower _bgra>] (
+                width: u32,
+                height: u32,
+                last_src_plane: u32,
+                src_strides: &[usize],
+                src_buffers: &[&[u8]],
+                last_dst_plane: u32,
+                dst_strides: &[usize],
+                dst_buffers: &mut [&mut [u8]],
+            ) -> bool {
+                [<$src_pf:lower _bgra>](
+                    width,
+                    height,
+                    last_src_plane as usize,
+                    src_strides,
+                    src_buffers,
+                    last_dst_plane as usize,
+                    dst_strides,
+                    dst_buffers,
+                    Colorimetry::$src_cs as usize,
+                )
+            }
+        }
+    };
+}
+
 #[cfg(not(tarpaulin_include))]
 const fn enum_count(lo: u32, hi: u32) -> u32 {
     hi - lo + 1

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -32,7 +32,7 @@ macro_rules! rgb_to_yuv_converter {
                 dst_strides: &[usize],
                 dst_buffers: &mut [&mut [u8]],
             ) -> bool {
-                [<rgb _ $dst_pf:lower>](
+                [<rgb _ $dst_pf:lower>]::<{ Sampler::$src_pf as usize }, { sampler_to_depth(Sampler::$src_pf) }, { Colorimetry::$dst_cs as usize }>(
                     width,
                     height,
                     last_src_plane as usize,
@@ -41,8 +41,6 @@ macro_rules! rgb_to_yuv_converter {
                     last_dst_plane as usize,
                     dst_strides,
                     dst_buffers,
-                    Colorimetry::$dst_cs as usize,
-                    Sampler::$src_pf,
                 )
             }
         }
@@ -64,7 +62,7 @@ macro_rules! yuv_to_rgb_converter {
                 dst_strides: &[usize],
                 dst_buffers: &mut [&mut [u8]],
             ) -> bool {
-                [<$src_pf:lower _bgra>](
+                [<$src_pf:lower _bgra>]::<{ Colorimetry::$src_cs as usize }, { sampler_to_depth(Sampler::Bgra) }>(
                     width,
                     height,
                     last_src_plane as usize,
@@ -73,7 +71,6 @@ macro_rules! yuv_to_rgb_converter {
                     last_dst_plane as usize,
                     dst_strides,
                     dst_buffers,
-                    Colorimetry::$src_cs as usize,
                 )
             }
         }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -33,8 +33,8 @@ const LO_YUV_PIXEL_FORMAT: u32 = PixelFormat::I444 as u32;
 const HI_YUV_PIXEL_FORMAT: u32 = PixelFormat::Nv12 as u32;
 static_assert!(HI_RGB_PIXEL_FORMAT == LO_YUV_PIXEL_FORMAT - 1);
 
-const LO_RGB_COLOR_SPACE: u32 = ColorSpace::Lrgb as u32;
-const HI_RGB_COLOR_SPACE: u32 = ColorSpace::Lrgb as u32;
+const LO_RGB_COLOR_SPACE: u32 = ColorSpace::Rgb as u32;
+const HI_RGB_COLOR_SPACE: u32 = ColorSpace::Rgb as u32;
 const LO_YUV_COLOR_SPACE: u32 = ColorSpace::Bt601 as u32;
 const HI_YUV_COLOR_SPACE: u32 = ColorSpace::Bt709FR as u32;
 static_assert!(HI_RGB_COLOR_SPACE == LO_YUV_COLOR_SPACE - 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //!
 //!     let src_format = ImageFormat {
 //!         pixel_format: PixelFormat::Bgra,
-//!         color_space: ColorSpace::Lrgb,
+//!         color_space: ColorSpace::Rgb,
 //!         num_planes: 1,
 //!     };
 //!
@@ -162,7 +162,7 @@
 //!
 //!     let format = ImageFormat {
 //!         pixel_format: PixelFormat::Bgra,
-//!         color_space: ColorSpace::Lrgb,
+//!         color_space: ColorSpace::Rgb,
 //!         num_planes: NUM_PLANES,
 //!     };
 //!
@@ -208,7 +208,7 @@
 //!
 //!     let dst_format = ImageFormat {
 //!         pixel_format: PixelFormat::Bgra,
-//!         color_space: ColorSpace::Lrgb,
+//!         color_space: ColorSpace::Rgb,
 //!         num_planes: NUM_DST_PLANES,
 //!     };
 //!
@@ -250,7 +250,7 @@
 //!
 //!     let src_format = ImageFormat {
 //!         pixel_format: PixelFormat::Bgr,
-//!         color_space: ColorSpace::Lrgb,
+//!         color_space: ColorSpace::Rgb,
 //!         num_planes: NUM_SRC_PLANES,
 //!     };
 //!
@@ -356,11 +356,11 @@ impl error::Error for ErrorKind {
 ///
 /// pixel format        | color space
 /// --------------------|--------------------------------------
-/// `PixelFormat::Argb` | `ColorSpace::Lrgb`
-/// `PixelFormat::Bgra` | `ColorSpace::Lrgb`
-/// `PixelFormat::Bgr`  | `ColorSpace::Lrgb`
-/// `PixelFormat::Rgba` | `ColorSpace::Lrgb`
-/// `PixelFormat::Rgb`  | `ColorSpace::Lrgb`
+/// `PixelFormat::Argb` | `ColorSpace::Rgb`
+/// `PixelFormat::Bgra` | `ColorSpace::Rgb`
+/// `PixelFormat::Bgr`  | `ColorSpace::Rgb`
+/// `PixelFormat::Rgba` | `ColorSpace::Rgb`
+/// `PixelFormat::Rgb`  | `ColorSpace::Rgb`
 /// `PixelFormat::I444` | `ColorSpace::Bt601(FR)`, `ColorSpace::Bt709(FR)`
 /// `PixelFormat::I422` | `ColorSpace::Bt601(FR)`, `ColorSpace::Bt709(FR)`
 /// `PixelFormat::I420` | `ColorSpace::Bt601(FR)`, `ColorSpace::Bt709(FR)`
@@ -417,58 +417,58 @@ macro_rules! set_dispatcher {
 
 macro_rules! set_dispatch_table {
     ($conv:expr, $set:ident) => {
-        set_dispatcher!($conv, $set, Argb, Lrgb, I420, Bt601);
-        set_dispatcher!($conv, $set, Argb, Lrgb, I420, Bt709);
-        set_dispatcher!($conv, $set, Argb, Lrgb, I444, Bt601);
-        set_dispatcher!($conv, $set, Argb, Lrgb, I444, Bt709);
-        set_dispatcher!($conv, $set, Argb, Lrgb, Nv12, Bt601);
-        set_dispatcher!($conv, $set, Argb, Lrgb, Nv12, Bt709);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, I420, Bt601);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, I420, Bt709);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, I444, Bt601);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, I444, Bt709);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, Nv12, Bt601);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, Nv12, Bt709);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, Rgb, Lrgb);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, I420, Bt601);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, I420, Bt709);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, I444, Bt601);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, I444, Bt709);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, Nv12, Bt601);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, Nv12, Bt709);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, Rgb, Lrgb);
-        set_dispatcher!($conv, $set, I420, Bt601, Bgra, Lrgb);
-        set_dispatcher!($conv, $set, I420, Bt709, Bgra, Lrgb);
-        set_dispatcher!($conv, $set, I444, Bt601, Bgra, Lrgb);
-        set_dispatcher!($conv, $set, I444, Bt709, Bgra, Lrgb);
-        set_dispatcher!($conv, $set, Nv12, Bt601, Bgra, Lrgb);
-        set_dispatcher!($conv, $set, Nv12, Bt709, Bgra, Lrgb);
-        set_dispatcher!($conv, $set, Rgb, Lrgb, Bgra, Lrgb);
+        set_dispatcher!($conv, $set, Argb, Rgb, I420, Bt601);
+        set_dispatcher!($conv, $set, Argb, Rgb, I420, Bt709);
+        set_dispatcher!($conv, $set, Argb, Rgb, I444, Bt601);
+        set_dispatcher!($conv, $set, Argb, Rgb, I444, Bt709);
+        set_dispatcher!($conv, $set, Argb, Rgb, Nv12, Bt601);
+        set_dispatcher!($conv, $set, Argb, Rgb, Nv12, Bt709);
+        set_dispatcher!($conv, $set, Bgr, Rgb, I420, Bt601);
+        set_dispatcher!($conv, $set, Bgr, Rgb, I420, Bt709);
+        set_dispatcher!($conv, $set, Bgr, Rgb, I444, Bt601);
+        set_dispatcher!($conv, $set, Bgr, Rgb, I444, Bt709);
+        set_dispatcher!($conv, $set, Bgr, Rgb, Nv12, Bt601);
+        set_dispatcher!($conv, $set, Bgr, Rgb, Nv12, Bt709);
+        set_dispatcher!($conv, $set, Bgr, Rgb, Rgb, Rgb);
+        set_dispatcher!($conv, $set, Bgra, Rgb, I420, Bt601);
+        set_dispatcher!($conv, $set, Bgra, Rgb, I420, Bt709);
+        set_dispatcher!($conv, $set, Bgra, Rgb, I444, Bt601);
+        set_dispatcher!($conv, $set, Bgra, Rgb, I444, Bt709);
+        set_dispatcher!($conv, $set, Bgra, Rgb, Nv12, Bt601);
+        set_dispatcher!($conv, $set, Bgra, Rgb, Nv12, Bt709);
+        set_dispatcher!($conv, $set, Bgra, Rgb, Rgb, Rgb);
+        set_dispatcher!($conv, $set, I420, Bt601, Bgra, Rgb);
+        set_dispatcher!($conv, $set, I420, Bt709, Bgra, Rgb);
+        set_dispatcher!($conv, $set, I444, Bt601, Bgra, Rgb);
+        set_dispatcher!($conv, $set, I444, Bt709, Bgra, Rgb);
+        set_dispatcher!($conv, $set, Nv12, Bt601, Bgra, Rgb);
+        set_dispatcher!($conv, $set, Nv12, Bt709, Bgra, Rgb);
+        set_dispatcher!($conv, $set, Rgb, Rgb, Bgra, Rgb);
 
-        set_dispatcher!($conv, $set, Argb, Lrgb, I420, Bt601FR);
-        set_dispatcher!($conv, $set, Argb, Lrgb, I420, Bt709FR);
-        set_dispatcher!($conv, $set, Argb, Lrgb, I444, Bt601FR);
-        set_dispatcher!($conv, $set, Argb, Lrgb, I444, Bt709FR);
-        set_dispatcher!($conv, $set, Argb, Lrgb, Nv12, Bt601FR);
-        set_dispatcher!($conv, $set, Argb, Lrgb, Nv12, Bt709FR);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, I420, Bt601FR);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, I420, Bt709FR);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, I444, Bt601FR);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, I444, Bt709FR);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, Nv12, Bt601FR);
-        set_dispatcher!($conv, $set, Bgr, Lrgb, Nv12, Bt709FR);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, I420, Bt601FR);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, I420, Bt709FR);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, I444, Bt601FR);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, I444, Bt709FR);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, Nv12, Bt601FR);
-        set_dispatcher!($conv, $set, Bgra, Lrgb, Nv12, Bt709FR);
-        set_dispatcher!($conv, $set, I420, Bt601FR, Bgra, Lrgb);
-        set_dispatcher!($conv, $set, I420, Bt709FR, Bgra, Lrgb);
-        set_dispatcher!($conv, $set, I444, Bt601FR, Bgra, Lrgb);
-        set_dispatcher!($conv, $set, I444, Bt709FR, Bgra, Lrgb);
-        set_dispatcher!($conv, $set, Nv12, Bt601FR, Bgra, Lrgb);
-        set_dispatcher!($conv, $set, Nv12, Bt709FR, Bgra, Lrgb);
+        set_dispatcher!($conv, $set, Argb, Rgb, I420, Bt601FR);
+        set_dispatcher!($conv, $set, Argb, Rgb, I420, Bt709FR);
+        set_dispatcher!($conv, $set, Argb, Rgb, I444, Bt601FR);
+        set_dispatcher!($conv, $set, Argb, Rgb, I444, Bt709FR);
+        set_dispatcher!($conv, $set, Argb, Rgb, Nv12, Bt601FR);
+        set_dispatcher!($conv, $set, Argb, Rgb, Nv12, Bt709FR);
+        set_dispatcher!($conv, $set, Bgr, Rgb, I420, Bt601FR);
+        set_dispatcher!($conv, $set, Bgr, Rgb, I420, Bt709FR);
+        set_dispatcher!($conv, $set, Bgr, Rgb, I444, Bt601FR);
+        set_dispatcher!($conv, $set, Bgr, Rgb, I444, Bt709FR);
+        set_dispatcher!($conv, $set, Bgr, Rgb, Nv12, Bt601FR);
+        set_dispatcher!($conv, $set, Bgr, Rgb, Nv12, Bt709FR);
+        set_dispatcher!($conv, $set, Bgra, Rgb, I420, Bt601FR);
+        set_dispatcher!($conv, $set, Bgra, Rgb, I420, Bt709FR);
+        set_dispatcher!($conv, $set, Bgra, Rgb, I444, Bt601FR);
+        set_dispatcher!($conv, $set, Bgra, Rgb, I444, Bt709FR);
+        set_dispatcher!($conv, $set, Bgra, Rgb, Nv12, Bt601FR);
+        set_dispatcher!($conv, $set, Bgra, Rgb, Nv12, Bt709FR);
+        set_dispatcher!($conv, $set, I420, Bt601FR, Bgra, Rgb);
+        set_dispatcher!($conv, $set, I420, Bt709FR, Bgra, Rgb);
+        set_dispatcher!($conv, $set, I444, Bt601FR, Bgra, Rgb);
+        set_dispatcher!($conv, $set, I444, Bt709FR, Bgra, Rgb);
+        set_dispatcher!($conv, $set, Nv12, Bt601FR, Bgra, Rgb);
+        set_dispatcher!($conv, $set, Nv12, Bt709FR, Bgra, Rgb);
     };
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -57,7 +57,7 @@ const PIXEL_FORMATS: &[PixelFormat; 9] = &[
 ];
 
 const COLOR_SPACES: &[ColorSpace; 5] = &[
-    ColorSpace::Lrgb,
+    ColorSpace::Rgb,
     ColorSpace::Bt601,
     ColorSpace::Bt709,
     ColorSpace::Bt601FR,
@@ -67,7 +67,7 @@ const COLOR_SPACES: &[ColorSpace; 5] = &[
 const PIXEL_FORMAT_I444: u32 = PixelFormat::I444 as u32;
 const PIXEL_FORMAT_I422: u32 = PixelFormat::I422 as u32;
 const PIXEL_FORMAT_I420: u32 = PixelFormat::I420 as u32;
-const COLOR_SPACE_LRGB: u32 = ColorSpace::Lrgb as u32;
+const COLOR_SPACE_RGB: u32 = ColorSpace::Rgb as u32;
 const PIXEL_FORMAT_ARGB: u32 = PixelFormat::Argb as u32;
 const PIXEL_FORMAT_BGRA: u32 = PixelFormat::Bgra as u32;
 const PIXEL_FORMAT_BGR: u32 = PixelFormat::Bgr as u32;
@@ -608,12 +608,12 @@ fn bootstrap(set: &str) {
                 let dst_buffers: &mut [&mut [u8]] = &mut [&mut [0_u8; 3 * PIXELS]];
                 let src_format = ImageFormat {
                     pixel_format: PixelFormat::Bgra,
-                    color_space: ColorSpace::Lrgb,
+                    color_space: ColorSpace::Rgb,
                     num_planes: 1,
                 };
                 let dst_format = ImageFormat {
                     pixel_format: PixelFormat::Rgb,
-                    color_space: ColorSpace::Lrgb,
+                    color_space: ColorSpace::Rgb,
                     num_planes: 1,
                 };
                 let sizes = &mut [0_usize; 1];
@@ -845,7 +845,7 @@ fn rgb_to_yuv_size(
             image_size,
             &ImageFormat {
                 pixel_format: *pixel_format,
-                color_space: ColorSpace::Lrgb,
+                color_space: ColorSpace::Rgb,
                 num_planes: 1,
             },
             dst_image_format,
@@ -1159,7 +1159,7 @@ fn yuv_to_rgb_ok(pixel_format: PixelFormat, num_planes: u32) {
     };
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
@@ -1178,7 +1178,7 @@ fn yuv_to_rgb_ok(pixel_format: PixelFormat, num_planes: u32) {
     }
 }
 
-fn lrgb_conversion_errors(src_pixel_format: PixelFormat, dst_pixel_format: PixelFormat) {
+fn rgb_conversion_errors(src_pixel_format: PixelFormat, dst_pixel_format: PixelFormat) {
     const WIDTH: u32 = 33;
     const HEIGHT: u32 = 1;
 
@@ -1195,12 +1195,12 @@ fn lrgb_conversion_errors(src_pixel_format: PixelFormat, dst_pixel_format: Pixel
     for num_planes in 0..4 {
         let src_format = ImageFormat {
             pixel_format: src_pixel_format,
-            color_space: ColorSpace::Lrgb,
+            color_space: ColorSpace::Rgb,
             num_planes: 1,
         };
         let dst_format = ImageFormat {
             pixel_format: dst_pixel_format,
-            color_space: ColorSpace::Lrgb,
+            color_space: ColorSpace::Rgb,
             num_planes,
         };
 
@@ -1245,7 +1245,7 @@ fn lrgb_conversion_errors(src_pixel_format: PixelFormat, dst_pixel_format: Pixel
     }
 }
 
-fn lrgb_conversion_ok(src_pixel_format: PixelFormat, dst_pixel_format: PixelFormat) {
+fn rgb_conversion_ok(src_pixel_format: PixelFormat, dst_pixel_format: PixelFormat) {
     const MAX_WIDTH: u32 = 49;
     const MAX_HEIGHT: u32 = 8;
     const MAX_PAD: usize = 3;
@@ -1255,12 +1255,12 @@ fn lrgb_conversion_ok(src_pixel_format: PixelFormat, dst_pixel_format: PixelForm
 
     let src_format = ImageFormat {
         pixel_format: src_pixel_format,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
     let dst_format = ImageFormat {
         pixel_format: dst_pixel_format,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
     let mut rng = rand::thread_rng();
@@ -1353,16 +1353,16 @@ fn i444_to_rgb_ok() {
     yuv_to_rgb_ok(PixelFormat::I444, 3);
 }
 
-fn lrgb_ok() {
-    lrgb_conversion_ok(PixelFormat::Rgb, PixelFormat::Bgra);
-    lrgb_conversion_ok(PixelFormat::Bgra, PixelFormat::Rgb);
-    lrgb_conversion_ok(PixelFormat::Bgr, PixelFormat::Rgb);
+fn rgb_ok() {
+    rgb_conversion_ok(PixelFormat::Rgb, PixelFormat::Bgra);
+    rgb_conversion_ok(PixelFormat::Bgra, PixelFormat::Rgb);
+    rgb_conversion_ok(PixelFormat::Bgr, PixelFormat::Rgb);
 }
 
-fn lrgb_errors() {
-    lrgb_conversion_errors(PixelFormat::Rgb, PixelFormat::Bgra);
-    lrgb_conversion_errors(PixelFormat::Bgra, PixelFormat::Rgb);
-    lrgb_conversion_errors(PixelFormat::Bgr, PixelFormat::Rgb);
+fn rgb_errors() {
+    rgb_conversion_errors(PixelFormat::Rgb, PixelFormat::Bgra);
+    rgb_conversion_errors(PixelFormat::Bgra, PixelFormat::Rgb);
+    rgb_conversion_errors(PixelFormat::Bgr, PixelFormat::Rgb);
 }
 
 fn rgb_to_yuv_errors(pixel_format: PixelFormat) {
@@ -1432,8 +1432,8 @@ fn rgb_to_yuv_errors(pixel_format: PixelFormat) {
             let src_cs = *src_color_space as u32;
             let dst_cs = *dst_color_space as u32;
             let src_pf_rgb = src_pf < PIXEL_FORMAT_I444;
-            let src_cs_rgb = src_cs == COLOR_SPACE_LRGB;
-            let dst_cs_rgb = dst_cs == COLOR_SPACE_LRGB;
+            let src_cs_rgb = src_cs == COLOR_SPACE_RGB;
+            let dst_cs_rgb = dst_cs == COLOR_SPACE_RGB;
 
             set_expected!(expected, !src_pf_rgb && src_cs_rgb, ErrorKind::InvalidValue);
             set_expected!(expected, src_pf_rgb && !src_cs_rgb, ErrorKind::InvalidValue);
@@ -1457,7 +1457,7 @@ fn rgb_to_yuv_errors(pixel_format: PixelFormat) {
             );
             set_expected!(
                 expected,
-                src_cs != COLOR_SPACE_LRGB,
+                src_cs != COLOR_SPACE_RGB,
                 ErrorKind::InvalidOperation
             );
 
@@ -1552,8 +1552,8 @@ fn yuv_to_rgb_errors(pixel_format: PixelFormat) {
         let dst_cs = *dst_color_space as u32;
         let src_cs = *src_color_space as u32;
         let dst_pf_rgb = dst_pf < PIXEL_FORMAT_I444;
-        let dst_cs_rgb = dst_cs == COLOR_SPACE_LRGB;
-        let src_cs_rgb = src_cs == COLOR_SPACE_LRGB;
+        let dst_cs_rgb = dst_cs == COLOR_SPACE_RGB;
+        let src_cs_rgb = src_cs == COLOR_SPACE_RGB;
 
         set_expected!(expected, src_cs_rgb, ErrorKind::InvalidValue);
         set_expected!(expected, !dst_pf_rgb && dst_cs_rgb, ErrorKind::InvalidValue);
@@ -1575,7 +1575,7 @@ fn yuv_to_rgb_errors(pixel_format: PixelFormat) {
         );
         set_expected!(
             expected,
-            dst_cs != COLOR_SPACE_LRGB,
+            dst_cs != COLOR_SPACE_RGB,
             ErrorKind::InvalidOperation
         );
 
@@ -1607,7 +1607,7 @@ fn buffers_size() {
         let pf = *pixel_format as u32;
         let format = ImageFormat {
             pixel_format: *pixel_format,
-            color_space: ColorSpace::Lrgb,
+            color_space: ColorSpace::Rgb,
             num_planes,
         };
 
@@ -1734,7 +1734,7 @@ fn over_4gb() {
     };
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
-        color_space: ColorSpace::Lrgb,
+        color_space: ColorSpace::Rgb,
         num_planes: 1,
     };
 
@@ -1815,7 +1815,7 @@ fn functional_tests() {
         rgb_to_yuv_errors(PixelFormat::Nv12);
         rgb_to_yuv_errors(PixelFormat::I420);
         rgb_to_yuv_errors(PixelFormat::I444);
-        lrgb_errors();
+        rgb_errors();
 
         i444_to_rgb_ok();
         i420_to_rgb_ok();
@@ -1824,7 +1824,7 @@ fn functional_tests() {
         rgb_to_i420_ok();
         rgb_to_nv12_ok();
 
-        lrgb_ok();
+        rgb_ok();
     }
 
     #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/dcv-color-primitives/issues/63

*Description of changes:*
- Relevant commits for the issue resolution are:
  - [Rename 'lrgb' to 'rgb'](https://github.com/aws/dcv-color-primitives/commit/88e0e33fdd025a515e5faaf3fc55b0b8ff7ba21c)
  - [Bump to 0.5.0](https://github.com/aws/dcv-color-primitives/commit/b9d57c9cee44d96a904b31f46a40a34042237a63)

Side commits are just making the code less harder to read, using paste! macro and const generics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
