### PR TITLE
Avoid reading invalid data for rgb to bgra conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,39 @@ jobs:
       - name: Test
         run: wasm-pack test --node
 
+  sanitizer:
+    name: Sanitizer
+    runs-on: ubuntu-latest
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-gnu
+
+      - name: Sanitizer
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --target=x86_64-unknown-linux-gnu
+        env:
+          RUSTFLAGS: -Zsanitizer=address
+
+      - name: Sanitizer (instruction sets)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --tests --target=x86_64-unknown-linux-gnu --features "test_instruction_sets"
+        env:
+          RUSTFLAGS: -Zsanitizer=address
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    needs: build
+    needs: sanitizer
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           target: x86_64-unknown-linux-gnu
 
       - name: Sanitizer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,16 +139,16 @@ jobs:
       - name: Sanitizer
         uses: actions-rs/cargo@v1
         with:
-          command: test +nightly
-          args: --verbose --target=x86_64-unknown-linux-gnu
+          command: test
+          args: +nightly --verbose --target=x86_64-unknown-linux-gnu
         env:
           RUSTFLAGS: -Zsanitizer=address
 
       - name: Sanitizer (instruction sets)
         uses: actions-rs/cargo@v1
         with:
-          command: test +nightly
-          args: --verbose --tests --target=x86_64-unknown-linux-gnu --features "test_instruction_sets"
+          command: test
+          args: +nightly --verbose --tests --target=x86_64-unknown-linux-gnu --features "test_instruction_sets"
         env:
           RUSTFLAGS: -Zsanitizer=address
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,13 +137,11 @@ jobs:
           target: x86_64-unknown-linux-gnu
 
       - name: Sanitizer
-        uses: actions-rs/cargo@v1
         run: cargo +nightly test --verbose --target=x86_64-unknown-linux-gnu
         env:
           RUSTFLAGS: -Zsanitizer=address
 
       - name: Sanitizer (instruction sets)
-        uses: actions-rs/cargo@v1
         run: cargo +nightly test --verbose --tests --target=x86_64-unknown-linux-gnu --features "test_instruction_sets"
         env:
           RUSTFLAGS: -Zsanitizer=address

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,16 +139,16 @@ jobs:
       - name: Sanitizer
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: +nightly --verbose --target=x86_64-unknown-linux-gnu
+          run: cargo
+          args: +nightly test --verbose --target=x86_64-unknown-linux-gnu
         env:
           RUSTFLAGS: -Zsanitizer=address
 
       - name: Sanitizer (instruction sets)
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: +nightly --verbose --tests --target=x86_64-unknown-linux-gnu --features "test_instruction_sets"
+          run: cargo
+          args: +nightly test --verbose --tests --target=x86_64-unknown-linux-gnu --features "test_instruction_sets"
         env:
           RUSTFLAGS: -Zsanitizer=address
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Sanitizer
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: test +nightly
           args: --verbose --target=x86_64-unknown-linux-gnu
         env:
           RUSTFLAGS: -Zsanitizer=address
@@ -147,7 +147,7 @@ jobs:
       - name: Sanitizer (instruction sets)
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: test +nightly
           args: --verbose --tests --target=x86_64-unknown-linux-gnu --features "test_instruction_sets"
         env:
           RUSTFLAGS: -Zsanitizer=address

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           target: x86_64-unknown-linux-gnu
 
       - name: Sanitizer
-        run: cargo +nightly test --verbose --target=x86_64-unknown-linux-gnu
+        run: cargo +nightly test --verbose --tests --target=x86_64-unknown-linux-gnu
         env:
           RUSTFLAGS: -Zsanitizer=address
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,17 +138,13 @@ jobs:
 
       - name: Sanitizer
         uses: actions-rs/cargo@v1
-        with:
-          run: cargo
-          args: +nightly test --verbose --target=x86_64-unknown-linux-gnu
+        run: cargo +nightly test --verbose --target=x86_64-unknown-linux-gnu
         env:
           RUSTFLAGS: -Zsanitizer=address
 
       - name: Sanitizer (instruction sets)
         uses: actions-rs/cargo@v1
-        with:
-          run: cargo
-          args: +nightly test --verbose --tests --target=x86_64-unknown-linux-gnu --features "test_instruction_sets"
+        run: cargo +nightly test --verbose --tests --target=x86_64-unknown-linux-gnu --features "test_instruction_sets"
         env:
           RUSTFLAGS: -Zsanitizer=address
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1764,7 +1764,7 @@ fn over_4gb() {
         let dst_layout = Layout::from_size_align_unchecked(EXPECTED_DST_BUFFER_SIZE, 1);
         let dst_ptr = alloc_zeroed(dst_layout);
         if !dst_ptr.is_null() {
-            let src_image = from_raw_parts_mut(src_ptr, EXPECTED_SRC_BUFFER_SIZE);
+            let src_image: &[u8] = from_raw_parts_mut(src_ptr, EXPECTED_SRC_BUFFER_SIZE);
             let dst_image = from_raw_parts_mut(dst_ptr, EXPECTED_DST_BUFFER_SIZE);
 
             // Touch output
@@ -1774,7 +1774,7 @@ fn over_4gb() {
 
             dst_image[dst_image.len() - 1] = 0;
 
-            let src_buffers = &[&src_image[..]];
+            let src_buffers = &[src_image];
             let dst_buffers = &mut [&mut *dst_image];
 
             assert!(convert_image(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Avoid reading invalid data for rgb to bgra conversion.

The function has two optimized path to load:
* 1 rgb item with a wide load of 4 bytes (1 byte discarded)
* 4 rgb items at once with a wide load of 26 bytes (2 byte discarded)

The paths rely on 1 byte (and respectively 2 bytes) of padding in the source buffer.

The assumption holds on all the lines is the image stride is greater than 3 * width (resp. 3 * width + 1), but could not hold on the last line, as the stride definition is 'distance from consecutive lines', but the last line has no following line, so we could not assume there is padding.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
