### PR TITLE
Fix documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,8 @@ fn main() {
     const WIDTH: u32 = 640;
     const HEIGHT: u32 = 480;
 
-    let src_buffers: &[&[u8]] = &[&[0u8; 4 * (WIDTH as usize) * (HEIGHT as usize)]];
-    let dst_buffers: &mut [&mut [u8]] =
-        &mut [&mut [0u8; 3 * (WIDTH as usize) * (HEIGHT as usize) / 2]];
+    let src_data = Box::new([0u8; 4 * (WIDTH as usize) * (HEIGHT as usize)]);
+    let mut dst_data = Box::new([0u8; 3 * (WIDTH as usize) * (HEIGHT as usize) / 2]);
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
@@ -157,10 +156,10 @@ fn main() {
         HEIGHT,
         &src_format,
         None,
-        src_buffers,
+        &[&*src_data],
         &dst_format,
         None,
-        dst_buffers,
+        &mut [&mut *dst_data],
     );
 }
 ```
@@ -190,9 +189,8 @@ fn main() {
     const WIDTH: u32 = 640;
     const HEIGHT: u32 = 480;
 
-    let src_buffers: &[&[u8]] = &[&[0u8; 4 * (WIDTH as usize) * (HEIGHT as usize)]];
-    let dst_buffers: &mut [&mut [u8]] =
-        &mut [&mut [0u8; 3 * (WIDTH as usize) * (HEIGHT as usize) / 2]];
+    let src_data = Box::new([0u8; 4 * (WIDTH as usize) * (HEIGHT as usize)]);
+    let mut dst_data = Box::new([0u8; 3 * (WIDTH as usize) * (HEIGHT as usize) / 2]);
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
@@ -211,10 +209,10 @@ fn main() {
         HEIGHT,
         &src_format,
         None,
-        src_buffers,
+        &[&*src_data],
         &dst_format,
         None,
-        dst_buffers,
+        &mut [&mut *dst_data],
     );
 
     match status {
@@ -236,9 +234,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     const WIDTH: u32 = 640;
     const HEIGHT: u32 = 480;
 
-    let src_buffers: &[&[u8]] = &[&[0u8; 4 * (WIDTH as usize) * (HEIGHT as usize)]];
-    let dst_buffers: &mut [&mut [u8]] =
-        &mut [&mut [0u8; 3 * (WIDTH as usize) * (HEIGHT as usize) / 2]];
+    let src_data = Box::new([0u8; 4 * (WIDTH as usize) * (HEIGHT as usize)]);
+    let mut dst_data = Box::new([0u8; 3 * (WIDTH as usize) * (HEIGHT as usize) / 2]);
 
     let src_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
@@ -257,10 +254,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         HEIGHT,
         &src_format,
         None,
-        src_buffers,
+        &[&*src_data],
         &dst_format,
         None,
-        dst_buffers,
+        &mut [&mut *dst_data],
     )?;
 
     Ok(())
@@ -331,7 +328,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let src_y: Vec<_> = vec![0u8; src_sizes[0]];
     let src_uv: Vec<_> = vec![0u8; src_sizes[1]];
-    let src_buffers: &[&[u8]] = &[&src_y[..], &src_uv[..]];
 
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Bgra,
@@ -343,17 +339,16 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     get_buffers_size(WIDTH, HEIGHT, &dst_format, None, dst_sizes)?;
 
     let mut dst_rgba: Vec<_> = vec![0u8; dst_sizes[0]];
-    let dst_buffers: &mut [&mut [u8]] = &mut [&mut dst_rgba[..]];
 
     convert_image(
         WIDTH,
         HEIGHT,
         &src_format,
         None,
-        src_buffers,
+        &[&src_y[..], &src_uv[..]],
         &dst_format,
         None,
-        dst_buffers,
+        &mut [&mut dst_rgba[..]],
     )?;
 
     Ok(())
@@ -390,7 +385,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     get_buffers_size(WIDTH, HEIGHT, &src_format, Some(src_strides), src_sizes)?;
 
     let src_rgba: Vec<_> = vec![0u8; src_sizes[0]];
-    let src_buffers: &[&[u8]] = &[&src_rgba[..]];
 
     let dst_format = ImageFormat {
         pixel_format: PixelFormat::Nv12,
@@ -403,17 +397,16 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let mut dst_y: Vec<_> = vec![0u8; dst_sizes[0]];
     let mut dst_uv: Vec<_> = vec![0u8; dst_sizes[1]];
-    let dst_buffers: &mut [&mut [u8]] = &mut [&mut dst_y[..], &mut dst_uv[..]];
 
     convert_image(
         WIDTH,
         HEIGHT,
         &src_format,
         Some(src_strides),
-        src_buffers,
+        &[&src_rgba[..]],
         &dst_format,
         None,
-        dst_buffers,
+        &mut [&mut dst_y[..], &mut dst_uv[..]],
     )?;
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,8 @@
 //!     const WIDTH: u32 = 640;
 //!     const HEIGHT: u32 = 480;
 //!
-//!     let src_buffers: &[&[u8]] = &[&[0u8; 4 * (WIDTH as usize) * (HEIGHT as usize)]];
-//!     let dst_buffers: &mut [&mut [u8]] =
-//!         &mut [&mut [0u8; 3 * (WIDTH as usize) * (HEIGHT as usize) / 2]];
+//!     let src_data = Box::new([0u8; 4 * (WIDTH as usize) * (HEIGHT as usize)]);
+//!     let mut dst_data = Box::new([0u8; 3 * (WIDTH as usize) * (HEIGHT as usize) / 2]);
 //!
 //!     let src_format = ImageFormat {
 //!         pixel_format: PixelFormat::Bgra,
@@ -96,10 +95,10 @@
 //!         HEIGHT,
 //!         &src_format,
 //!         None,
-//!         src_buffers,
+//!         &[&*src_data],
 //!         &dst_format,
 //!         None,
-//!         dst_buffers,
+//!         &mut [&mut *dst_data],
 //!     );
 //! }
 //! ```
@@ -116,9 +115,8 @@
 //!     const WIDTH: u32 = 640;
 //!     const HEIGHT: u32 = 480;
 //!
-//!     let src_buffers: &[&[u8]] = &[&[0u8; 4 * (WIDTH as usize) * (HEIGHT as usize)]];
-//!     let dst_buffers: &mut [&mut [u8]] =
-//!         &mut [&mut [0u8; 3 * (WIDTH as usize) * (HEIGHT as usize) / 2]];
+//!     let src_data = Box::new([0u8; 4 * (WIDTH as usize) * (HEIGHT as usize)]);
+//!     let mut dst_data = Box::new([0u8; 3 * (WIDTH as usize) * (HEIGHT as usize) / 2]);
 //!
 //!     let src_format = ImageFormat {
 //!         pixel_format: PixelFormat::Bgra,
@@ -137,10 +135,10 @@
 //!         HEIGHT,
 //!         &src_format,
 //!         None,
-//!         src_buffers,
+//!         &[&*src_data],
 //!         &dst_format,
 //!         None,
-//!         dst_buffers,
+//!         &mut [&mut *dst_data],
 //!     )?;
 //!
 //!     Ok(())
@@ -178,7 +176,7 @@
 //! }
 //! ```
 //!
-//! Provide image planes to hangle data scattered in multiple buffers that are not
+//! Provide image planes to handle data scattered in multiple buffers that are not
 //! necessarily contiguous:
 //! ```
 //! use dcv_color_primitives as dcp;
@@ -204,7 +202,6 @@
 //!
 //!     let src_y: Vec<_> = vec![0u8; src_sizes[0]];
 //!     let src_uv: Vec<_> = vec![0u8; src_sizes[1]];
-//!     let src_buffers: &[&[u8]] = &[&src_y[..], &src_uv[..]];
 //!
 //!     let dst_format = ImageFormat {
 //!         pixel_format: PixelFormat::Bgra,
@@ -216,17 +213,16 @@
 //!     get_buffers_size(WIDTH, HEIGHT, &dst_format, None, dst_sizes)?;
 //!
 //!     let mut dst_rgba: Vec<_> = vec![0u8; dst_sizes[0]];
-//!     let dst_buffers: &mut [&mut [u8]] = &mut [&mut dst_rgba[..]];
 //!
 //!     convert_image(
 //!         WIDTH,
 //!         HEIGHT,
 //!         &src_format,
 //!         None,
-//!         src_buffers,
+//!         &[&src_y[..], &src_uv[..]],
 //!         &dst_format,
 //!         None,
-//!         dst_buffers,
+//!         &mut [&mut dst_rgba[..]],
 //!     )?;
 //!
 //!     Ok(())
@@ -260,7 +256,6 @@
 //!     get_buffers_size(WIDTH, HEIGHT, &src_format, Some(src_strides), src_sizes)?;
 //!
 //!     let src_rgba: Vec<_> = vec![0u8; src_sizes[0]];
-//!     let src_buffers: &[&[u8]] = &[&src_rgba[..]];
 //!
 //!     let dst_format = ImageFormat {
 //!         pixel_format: PixelFormat::Nv12,
@@ -273,17 +268,16 @@
 //!
 //!     let mut dst_y: Vec<_> = vec![0u8; dst_sizes[0]];
 //!     let mut dst_uv: Vec<_> = vec![0u8; dst_sizes[1]];
-//!     let dst_buffers: &mut [&mut [u8]] = &mut [&mut dst_y[..], &mut dst_uv[..]];
 //!
 //!     convert_image(
 //!         WIDTH,
 //!         HEIGHT,
 //!         &src_format,
 //!         Some(src_strides),
-//!         src_buffers,
+//!         &[&src_rgba[..]],
 //!         &dst_format,
 //!         None,
-//!         dst_buffers,
+//!         &mut [&mut dst_y[..], &mut dst_uv[..]],
 //!     )?;
 //!
 //!     Ok(())


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/dcv-color-primitives/issues/72

*Description of changes:*
Fix examples in the inline documentation and the README file to not use stack-allocated memory, as they largely depend on the linker stack size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
