### PR TITLE
meson: Require NtDll.dll

### DIFF
--- a/c_tests/meson.build
+++ b/c_tests/meson.build
@@ -7,6 +7,7 @@ dcp_deps = [
   userenv_dep,
   bcrypt_dep,
   librt_dep,
+  ntdll_dep,
 ]
 
 unit = executable(

--- a/meson.build
+++ b/meson.build
@@ -121,6 +121,7 @@ libdl_dep = cc.find_library('dl', required: is_win == false)
 ws2_32_dep = cc.find_library('ws2_32', required: is_win)
 userenv_dep = cc.find_library('userenv', required: is_win)
 bcrypt_dep = cc.find_library('bcrypt', required: is_win)
+ntdll_dep = cc.find_library('ntdll', required: is_win)
 
 clock_gettime_test_code = '''
   #include <time.h>


### PR DESCRIPTION
With Rust 1.70 the project fails to compile with meson:

```
[1/3] Compiling C object c_tests/unit.exe.p/unit.c.obj
[2/3] Linking target c_tests/unit.exe
FAILED: c_tests/unit.exe c_tests/unit.pdb
"link"  /MACHINE:x86 /OUT:c_tests/unit.exe c_tests/unit.exe.p/unit.c.obj "/nologo" "/release" "/nologo" "/DEBUG" "/PDB:c_tests\unit.pdb" "C:/build/build/Win32/debug/dcv-color-primitives/target/debug/dcv_color_primitives.lib" "ws2_32.lib" "userenv.lib" "bcrypt.lib" "/SUBSYSTEM:CONSOLE" "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "comdlg32.lib" "advapi32.lib"
dcv_color_primitives.lib(std-83289d9c1ef26d12.std.6b8e046a-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol __imp__NtCreateFile@44 referenced in function __ZN3std3sys7windows2fs20open_link_no_reparse17hff5a3ae9787ec0c0E
dcv_color_primitives.lib(std-83289d9c1ef26d12.std.6b8e046a-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol __imp__RtlNtStatusToDosError@4 referenced in function __ZN3std3sys7windows2fs20open_link_no_reparse17hff5a3ae9787ec0c0E
dcv_color_primitives.lib(std-83289d9c1ef26d12.std.6b8e046a-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol __imp__NtReadFile@36 referenced in function __ZN3std3sys7windows6handle6Handle16synchronous_read17hebb7dd13f4bc8861E
dcv_color_primitives.lib(std-83289d9c1ef26d12.std.6b8e046a-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol __imp__NtWriteFile@36 referenced in function __ZN3std3sys7windows6handle6Handle17synchronous_write17h552a28b5e7db1dabE
c_tests/unit.exe : fatal error LNK1120: 4 unresolved externals
```
