### PR TITLE
Added yuv to rgba conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The library is currenty able to convert the following pixel formats:
 | ARGB                 | I420, I444, NV12           |
 | BGR                  | I420, I444, NV12, RGB      |
 | BGRA                 | I420, I444, NV12, RGB      |
-| I420                 | BGRA                       |
-| I444                 | BGRA                       |
-| NV12                 | BGRA, RGB                  |
+| I420                 | BGRA, RGBA                 |
+| I444                 | BGRA, RGBA                 |
+| NV12                 | BGRA, RGB, RGBA            |
 | RGB                  | BGRA                       |
 
 ### Color models

--- a/include/dcv_color_primitives.h
+++ b/include/dcv_color_primitives.h
@@ -27,9 +27,9 @@
  * | ARGB                 | I420, I444, NV12           |
  * | BGR                  | I420, I444, NV12, RGB      |
  * | BGRA                 | I420, I444, NV12, RGB      |
- * | I420                 | BGRA                       |
- * | I444                 | BGRA                       |
- * | NV12                 | BGRA, RGB                  |
+ * | I420                 | BGRA, RGBA                 |
+ * | I444                 | BGRA, RGBA                 |
+ * | NV12                 | BGRA, RGB, RGBA            |
  * | RGB                  | BGRA                       |
  *
  * The supported color models are:
@@ -657,9 +657,9 @@ DcpResult           dcp_get_buffers_size        (uint32_t              width,
  *   DCP_PIXEL_FORMAT_BGR              | DCP_PIXEL_FORMAT_I444 [1][algo-1]
  *   DCP_PIXEL_FORMAT_BGR              | DCP_PIXEL_FORMAT_NV12 [1][algo-1]
  *   DCP_PIXEL_FORMAT_BGR              | DCP_PIXEL_FORMAT_RGB  [5][algo-5]
- *   DCP_PIXEL_FORMAT_I420             | DCP_PIXEL_FORMAT_BGRA [2][algo-2]
- *   DCP_PIXEL_FORMAT_I444             | DCP_PIXEL_FORMAT_BGRA [2][algo-2]
- *   DCP_PIXEL_FORMAT_NV12             | DCP_PIXEL_FORMAT_BGRA, DCP_PIXEL_FORMAT_RGB [2][algo-2]
+ *   DCP_PIXEL_FORMAT_I420             | DCP_PIXEL_FORMAT_BGRA, DCP_PIXEL_FORMAT_RGBA [2][algo-2]
+ *   DCP_PIXEL_FORMAT_I444             | DCP_PIXEL_FORMAT_BGRA, DCP_PIXEL_FORMAT_RGBA [2][algo-2]
+ *   DCP_PIXEL_FORMAT_NV12             | DCP_PIXEL_FORMAT_BGRA, DCP_PIXEL_FORMAT_RGB, DCP_PIXEL_FORMAT_RGBA [2][algo-2]
  *   DCP_PIXEL_FORMAT_RGB              | DCP_PIXEL_FORMAT_BGRA [3][algo-3]
  *
  * # Undefined behaviour

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -64,7 +64,10 @@ macro_rules! yuv_to_rgb_converter {
                 dst_strides: &[usize],
                 dst_buffers: &mut [&mut [u8]],
             ) -> bool {
-                [<$src_pf:lower _rgb>]::<{ Colorimetry::$src_cs as usize }, { crate::pixel_format::PixelFormat::depth(crate::pixel_format::PixelFormat::$dst_pf) }>(
+                [<$src_pf:lower _rgb>]::<
+                    { Colorimetry::$src_cs as usize },
+                    { crate::pixel_format::PixelFormat::depth(crate::pixel_format::PixelFormat::$dst_pf) },
+                    { crate::pixel_format::PixelFormat::reversed(crate::pixel_format::PixelFormat::$dst_pf) }>(
                     width,
                     height,
                     last_src_plane as usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,9 @@
 //! | ARGB                 | I420, I444, NV12           |
 //! | BGR                  | I420, I444, NV12, RGB      |
 //! | BGRA                 | I420, I444, NV12, RGB      |
-//! | I420                 | BGRA                       |
-//! | I444                 | BGRA                       |
-//! | NV12                 | BGRA, RGB                  |
+//! | I420                 | BGRA, RGBA                 |
+//! | I444                 | BGRA, RGBA                 |
+//! | NV12                 | BGRA, RGB, RGBA            |
 //! | RGB                  | BGRA                       |
 //!
 //! The supported color models are:
@@ -491,21 +491,33 @@ macro_rules! set_dispatch_table {
         rgb_to_yuv!($conv, $set, Bgra, Nv12, Bt709);
         rgb_to_yuv!($conv, $set, Bgra, Nv12, Bt709FR);
         yuv_to_rgb!($conv, $set, I420, Bt601, Bgra);
+        yuv_to_rgb!($conv, $set, I420, Bt601, Rgba);
         yuv_to_rgb!($conv, $set, I420, Bt601FR, Bgra);
+        yuv_to_rgb!($conv, $set, I420, Bt601FR, Rgba);
         yuv_to_rgb!($conv, $set, I420, Bt709, Bgra);
+        yuv_to_rgb!($conv, $set, I420, Bt709, Rgba);
         yuv_to_rgb!($conv, $set, I420, Bt709FR, Bgra);
+        yuv_to_rgb!($conv, $set, I420, Bt709FR, Rgba);
         yuv_to_rgb!($conv, $set, I444, Bt601, Bgra);
+        yuv_to_rgb!($conv, $set, I444, Bt601, Rgba);
         yuv_to_rgb!($conv, $set, I444, Bt601FR, Bgra);
+        yuv_to_rgb!($conv, $set, I444, Bt601FR, Rgba);
         yuv_to_rgb!($conv, $set, I444, Bt709, Bgra);
+        yuv_to_rgb!($conv, $set, I444, Bt709, Rgba);
         yuv_to_rgb!($conv, $set, I444, Bt709FR, Bgra);
+        yuv_to_rgb!($conv, $set, I444, Bt709FR, Rgba);
         yuv_to_rgb!($conv, $set, Nv12, Bt601, Bgra);
-        yuv_to_rgb!($conv, $set, Nv12, Bt601FR, Bgra);
-        yuv_to_rgb!($conv, $set, Nv12, Bt709, Bgra);
-        yuv_to_rgb!($conv, $set, Nv12, Bt709FR, Bgra);
         yuv_to_rgb!($conv, $set, Nv12, Bt601, Rgb);
+        yuv_to_rgb!($conv, $set, Nv12, Bt601, Rgba);
+        yuv_to_rgb!($conv, $set, Nv12, Bt601FR, Bgra);
         yuv_to_rgb!($conv, $set, Nv12, Bt601FR, Rgb);
+        yuv_to_rgb!($conv, $set, Nv12, Bt601FR, Rgba);
+        yuv_to_rgb!($conv, $set, Nv12, Bt709, Bgra);
         yuv_to_rgb!($conv, $set, Nv12, Bt709, Rgb);
+        yuv_to_rgb!($conv, $set, Nv12, Bt709, Rgba);
+        yuv_to_rgb!($conv, $set, Nv12, Bt709FR, Bgra);
         yuv_to_rgb!($conv, $set, Nv12, Bt709FR, Rgb);
+        yuv_to_rgb!($conv, $set, Nv12, Bt709FR, Rgba);
     };
 }
 
@@ -828,9 +840,9 @@ pub fn get_buffers_size(
 ///   `PixelFormat::Bgr`              | `PixelFormat::I444` [`1`]
 ///   `PixelFormat::Bgr`              | `PixelFormat::Nv12` [`1`]
 ///   `PixelFormat::Bgr`              | `PixelFormat::Rgb`  [`5`]
-///   `PixelFormat::I420`             | `PixelFormat::Bgra` [`2`]
-///   `PixelFormat::I444`             | `PixelFormat::Bgra` [`2`]
-///   `PixelFormat::Nv12`             | `PixelFormat::Bgra`, `PixelFormat::Rgb` [`2`]
+///   `PixelFormat::I420`             | `PixelFormat::Bgra`, `PixelFormat::Rgba` [`2`]
+///   `PixelFormat::I444`             | `PixelFormat::Bgra`, `PixelFormat::Rgba` [`2`]
+///   `PixelFormat::Nv12`             | `PixelFormat::Bgra`, `PixelFormat::Rgb`, `PixelFormat::Rgba` [`2`]
 ///   `PixelFormat::Rgb`              | `PixelFormat::Bgra` [`3`]
 ///
 /// * [`NotEnoughData`] if the source stride array is not `None` and its length is less than the

--- a/src/pixel_format.rs
+++ b/src/pixel_format.rs
@@ -70,6 +70,11 @@ impl PixelFormat {
             _ => 0,
         }
     }
+
+    #[cfg(not(tarpaulin_include))]
+    pub(crate) const fn reversed(pixel_format: PixelFormat) -> bool {
+        matches!(pixel_format, PixelFormat::Rgba)
+    }
 }
 
 #[cfg(not(tarpaulin_include))]


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/dcv-color-primitives/issues/76

*Description of changes:*
Added {i420,i444,nv12} > rgba conversions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
